### PR TITLE
fix image tif name visium

### DIFF
--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -76,7 +76,7 @@ class VisiumKeys(ModeEnum):
     IMAGE_HIRES_FILE = "spatial/tissue_hires_image.png"
     IMAGE_LOWRES_FILE = "spatial/tissue_lowres_image.png"
     IMAGE_TIF_SUFFIX = "_tissue_image.tif"
-    IMAGE_TIF_ALTERNATIVE_SUFFIX = '_image.tif'
+    IMAGE_TIF_ALTERNATIVE_SUFFIX = "_image.tif"
 
     # scalefactors
     SCALEFACTORS_FILE = "spatial/scalefactors_json.json"

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -76,6 +76,7 @@ class VisiumKeys(ModeEnum):
     IMAGE_HIRES_FILE = "spatial/tissue_hires_image.png"
     IMAGE_LOWRES_FILE = "spatial/tissue_lowres_image.png"
     IMAGE_TIF_SUFFIX = "_tissue_image.tif"
+    IMAGE_TIF_ALTERNATIVE_SUFFIX = '_image.tif'
 
     # scalefactors
     SCALEFACTORS_FILE = "spatial/scalefactors_json.json"

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -135,9 +135,7 @@ def visium(
     else:
         raise FileNotFoundError(f"Cannot find {VisiumKeys.IMAGE_TIF_FILE} or {VisiumKeys.IMAGE_TIF_ALTERNATIVE_FILE}.")
 
-    full_image = (
-        imread(tif_path, **imread_kwargs).squeeze().transpose(2, 0, 1)
-    )
+    full_image = imread(tif_path, **imread_kwargs).squeeze().transpose(2, 0, 1)
     full_image = DataArray(full_image, dims=("c", "y", "x"), name=dataset_id)
 
     image_hires = imread(path / VisiumKeys.IMAGE_HIRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -40,6 +40,7 @@ def visium(
         - ``{vx.IMAGE_HIRES_FILE!r}``: High resolution image.
         - ``{vx.IMAGE_LOWRES_FILE!r}``: Low resolution image.
         - ``<dataset_id>_`{vx.IMAGE_TIF_SUFFIX!r}```: High resolution tif image.
+        - ``<dataset_id>_`{vx.IMAGE_TIF_ALTERNATIVE_SUFFIX!r}```: High resolution tif image, old naming convention.
         - ``{vx.SCALEFACTORS_FILE!r}``: Scalefactors file.
         - ``{vx.SPOTS_FILE!r}``: Spots positions file.
 
@@ -127,8 +128,15 @@ def visium(
     adata.obs["region"] = dataset_id
     table = TableModel.parse(adata, region=dataset_id, region_key="region", instance_key="spot_id")
 
+    if (path / f"{dataset_id}{VisiumKeys.IMAGE_TIF_SUFFIX}").exists():
+        tif_path = path / f"{dataset_id}{VisiumKeys.IMAGE_TIF_SUFFIX}"
+    elif (path / f"{dataset_id}{VisiumKeys.IMAGE_TIF_ALTERNATIVE_SUFFIX}").exists():
+        tif_path = path / f"{dataset_id}{VisiumKeys.IMAGE_TIF_ALTERNATIVE_SUFFIX}"
+    else:
+        raise FileNotFoundError(f"Cannot find {VisiumKeys.IMAGE_TIF_FILE} or {VisiumKeys.IMAGE_TIF_ALTERNATIVE_FILE}.")
+
     full_image = (
-        imread(path / f"{dataset_id}{VisiumKeys.IMAGE_TIF_SUFFIX}", **imread_kwargs).squeeze().transpose(2, 0, 1)
+        imread(tif_path, **imread_kwargs).squeeze().transpose(2, 0, 1)
     )
     full_image = DataArray(full_image, dims=("c", "y", "x"), name=dataset_id)
 

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -133,7 +133,7 @@ def visium(
     elif (path / f"{dataset_id}{VisiumKeys.IMAGE_TIF_ALTERNATIVE_SUFFIX}").exists():
         tif_path = path / f"{dataset_id}{VisiumKeys.IMAGE_TIF_ALTERNATIVE_SUFFIX}"
     else:
-        raise FileNotFoundError(f"Cannot find {VisiumKeys.IMAGE_TIF_FILE} or {VisiumKeys.IMAGE_TIF_ALTERNATIVE_FILE}.")
+        raise FileNotFoundError(f"Cannot find {VisiumKeys.IMAGE_TIF_SUFFIX} or {VisiumKeys.IMAGE_TIF_ALTERNATIVE_SUFFIX}.")
 
     full_image = imread(tif_path, **imread_kwargs).squeeze().transpose(2, 0, 1)
     full_image = DataArray(full_image, dims=("c", "y", "x"), name=dataset_id)

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -133,7 +133,9 @@ def visium(
     elif (path / f"{dataset_id}{VisiumKeys.IMAGE_TIF_ALTERNATIVE_SUFFIX}").exists():
         tif_path = path / f"{dataset_id}{VisiumKeys.IMAGE_TIF_ALTERNATIVE_SUFFIX}"
     else:
-        raise FileNotFoundError(f"Cannot find {VisiumKeys.IMAGE_TIF_SUFFIX} or {VisiumKeys.IMAGE_TIF_ALTERNATIVE_SUFFIX}.")
+        raise FileNotFoundError(
+            f"Cannot find {VisiumKeys.IMAGE_TIF_SUFFIX} or {VisiumKeys.IMAGE_TIF_ALTERNATIVE_SUFFIX}."
+        )
 
     full_image = imread(tif_path, **imread_kwargs).squeeze().transpose(2, 0, 1)
     full_image = DataArray(full_image, dims=("c", "y", "x"), name=dataset_id)


### PR DESCRIPTION
the dataset `visium_io` from the sandbox doesn't have a `tissue_image.tif` file, only a `image.tif` file. I have changed the reader so that it looks for the`tissue_image.tif` first, and if this is not found, it looks for `image.tif`.