### PR TITLE
Mcmicro update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       rev: v1.4.1
       hooks:
           - id: mypy
-            additional_dependencies: [numpy]
+            additional_dependencies: [numpy, types-PyYAML]
             exclude: docs/
     - repo: https://github.com/asottile/yesqa
       rev: v1.5.0

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -148,11 +148,14 @@ class McmicroKeys(ModeEnum):
     LABELS_DIR = "segmentation"
     ILLUMINATION_DIR = "illumination"
     PARAMS_FILE = "qc/params.yml"
+    RAW_DIR = "raw"
 
     # metadata
     COORDS_X = "X_centroid"
     COORDS_Y = "Y_centroid"
     INSTANCE_KEY = "CellID"
+    ILLUMINATION_SUFFIX_DFP = "-dfp"
+    ILLUMINATION_SUFFIX_FFP = "-ffp"
 
 
 @unique

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -109,7 +109,6 @@ class McmicroKeys(ModeEnum):
     """Keys for *Mcmicro* formatted dataset."""
 
     # files and directories
-    CELL_FEATURES_SUFFIX = "--unmicst_cell.csv"
     QUANTIFICATION_DIR = "quantification"
     MARKERS_FILE = "markers.csv"
     IMAGES_DIR_WSI = "registration"

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -146,6 +146,7 @@ class McmicroKeys(ModeEnum):
     IMAGES_DIR_TMA = "dearray"
     IMAGE_SUFFIX = ".ome.tif"
     LABELS_DIR = "segmentation"
+    ILLUMINATION_DIR = "illumination"
     PARAMS_FILE = "qc/params.yml"
 
     # metadata

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -1,5 +1,7 @@
 from enum import unique
+
 from spatialdata_io._constants._enum import ModeEnum
+
 
 @unique
 class CosmxKeys(ModeEnum):

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -116,7 +116,6 @@ class McmicroKeys(ModeEnum):
     IMAGES_DIR_TMA = "dearray"
     IMAGE_SUFFIX = ".ome.tif"
     LABELS_DIR = "segmentation"
-    LABELS_PREFIX = "unmicst-"
 
     # metadata
     COORDS_X = "X_centroid"

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -149,6 +149,8 @@ class McmicroKeys(ModeEnum):
     ILLUMINATION_DIR = "illumination"
     PARAMS_FILE = "qc/params.yml"
     RAW_DIR = "raw"
+    COREOGRAPH_CENTROIDS = "qc/coreograph/centroidsY-X.txt"
+    COREOGRAPH_TMA_MAP = "qc/coreograph/TMA_MAP.tif"
 
     # metadata
     COORDS_X = "X_centroid"

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -146,6 +146,7 @@ class McmicroKeys(ModeEnum):
     IMAGES_DIR_TMA = "dearray"
     IMAGE_SUFFIX = ".ome.tif"
     LABELS_DIR = "segmentation"
+    PARAMS_FILE = "qc/params.yml"
 
     # metadata
     COORDS_X = "X_centroid"

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -1,7 +1,5 @@
 from enum import unique
-
 from spatialdata_io._constants._enum import ModeEnum
-
 
 @unique
 class CosmxKeys(ModeEnum):
@@ -112,7 +110,8 @@ class McmicroKeys(ModeEnum):
     CELL_FEATURES_SUFFIX = "--unmicst_cell.csv"
     QUANTIFICATION_DIR = "quantification"
     MARKERS_FILE = "markers.csv"
-    IMAGES_DIR = "registration"
+    IMAGES_DIR_WSI = "registration"
+    IMAGES_DIR_TMA = "dearray"
     IMAGE_SUFFIX = ".ome.tif"
     LABELS_DIR = "segmentation"
     LABELS_PREFIX = "unmicst-"

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -82,19 +82,6 @@ def mcmicro(
 
     images = {}
     if tma:
-        # tma_map_file = path / McmicroKeys.COREOGRAPH_TMA_MAP
-        # if not tma_map_file.exists():
-        #     raise ValueError(
-        #         f"{path} does not contain {McmicroKeys.COREOGRAPH_TMA_MAP} file, cannot map the TMA cores "
-        #         f"to the global image"
-        #     )
-        #
-        # data = imread(tma_map_file, **imread_kwargs).squeeze(0)
-        # data = Image2DModel.parse(
-        #     data, transformations=_get_transformation(), dims=("y", "x", "c"), **image_models_kwargs
-        # )
-        # images["tma_map"] = data
-
         centroids_file = path / McmicroKeys.COREOGRAPH_CENTROIDS
         tma_centroids = pd.read_csv(centroids_file, header=None, names=["y", "x"], index_col=False, sep=" ")
         tma_centroids.index = tma_centroids.index + 1

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -76,6 +76,8 @@ def mcmicro(
     else:
         image_dir = path / McmicroKeys.IMAGES_DIR_TMA
         samples = list(image_dir.glob("*" + McmicroKeys.IMAGE_SUFFIX))
+        image_dir_masks = image_dir / "masks"
+        samples_masks = list(image_dir_masks.glob("*"))
 
     images = {}
     for sample in samples:
@@ -119,6 +121,17 @@ def mcmicro(
             core_id = int(core_id_search.group()) if core_id_search else None
             labels[f"core_{core_id}_{segmentation_stem}"] = _get_labels(
                 label_path,
+                transformations,
+                imread_kwargs,
+                label_models_kwargs,
+            )
+
+    if tma:
+        for mask_path in samples_masks:
+            mask_stem = mask_path.stem
+
+            labels[f"core_{McmicroKeys.IMAGES_DIR_TMA}_{mask_stem}"] = _get_labels(
+                mask_path,
                 transformations,
                 imread_kwargs,
                 label_models_kwargs,

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -85,6 +85,15 @@ def mcmicro(
             image_models_kwargs,
         )
 
+    illumination_dir = path / McmicroKeys.ILLUMINATION_DIR
+    if illumination_dir.exists():
+        illumination_images = list(illumination_dir.glob("*"))
+        for illumination_image in illumination_images:
+            illumination_name = illumination_image.with_name(illumination_image.stem).with_suffix("").stem
+            images[illumination_name] = _get_images(
+                illumination_image, transformations, imread_kwargs, image_models_kwargs
+            )
+
     samples_labels = list((path / McmicroKeys.LABELS_DIR).glob("*/*" + McmicroKeys.IMAGE_SUFFIX))
 
     labels = {}

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -246,7 +246,6 @@ def _create_anndata(
     if not tma:
         region_value = sample_id + "_" + labels_basename
     else:
-        # Ensure unique CellIDs when concatenating anndata objects. Ensures unique values for INSTANCE_KEY
         region_value = "core_" + sample_id + "_" + labels_basename
         table[McmicroKeys.INSTANCE_KEY] = table[McmicroKeys.INSTANCE_KEY]
     adata = AnnData(

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -176,7 +176,8 @@ def _create_anndata(
     tma: bool,
 ) -> tuple[AnnData, str]:
     label_basename = csv_path.stem.split("_")[-1]
-    sample_id_search = re.search(r"^([a-zA-Z0-9-]*)--", csv_path.stem)
+    pattern = r"^(.*?)--"
+    sample_id_search = re.search(pattern, csv_path.stem)
     sample_id = sample_id_search.groups()[0] if sample_id_search else None
     if not sample_id:
         raise ValueError(

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -195,13 +195,6 @@ def _load_params(path: Path) -> Any:
     return params
 
 
-#     image = imread(
-#         path,
-#         **imread_kwargs,
-#     ).squeeze()
-#     return Labels2DModel.parse(image, transformations=transformations, **labels_models_kwargs)
-
-
 def _get_table(
     path: Path,
     marker_df: pd.DataFrame,

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -8,12 +8,14 @@ from typing import Any, Union
 
 import numpy as np
 import pandas as pd
+import yaml
 from anndata import AnnData
 from dask_image.imread import imread
 from multiscale_spatial_image.multiscale_spatial_image import MultiscaleSpatialImage
 from spatial_image import SpatialImage
 from spatialdata import SpatialData
 from spatialdata.models import Image2DModel, Labels2DModel, TableModel
+from yaml.loader import SafeLoader
 
 from spatialdata_io._constants._constants import McmicroKeys
 
@@ -53,6 +55,7 @@ def mcmicro(
     :class:`spatialdata.SpatialData`
     """
     path = Path(path)
+    _load_params(path)
 
     # Output directory dearray is specific for tissue micro array output of MCMICRO
     if (path / McmicroKeys.IMAGES_DIR_TMA).exists():
@@ -109,6 +112,13 @@ def mcmicro(
     table = _get_table(path, tma)
 
     return SpatialData(images=images, labels=labels, table=table)
+
+
+def _load_params(path: Path) -> Any:
+    params_path = path / McmicroKeys.PARAMS_FILE
+    with open(params_path) as fp:
+        params = yaml.load(fp, SafeLoader)
+    return params
 
 
 def _get_images(

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -199,5 +199,5 @@ def _create_anndata(
         obsm={"spatial": table[coords].to_numpy()},
         dtype=np.float_,
     )
-    adata.obs["region"] = region_value
+    adata.obs["region"] = pd.Categorical([region_value] * len(adata))
     return adata, region_value

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -151,7 +151,7 @@ def _load_params(path: Path) -> Any:
 
 def _get_images(
     path: Path,
-    transformations: Mapping[str, Identity],
+    transformations: dict[str, Identity],
     imread_kwargs: Mapping[str, Any] = MappingProxyType({}),
     image_models_kwargs: Mapping[str, Any] = MappingProxyType({}),
     marker_names: Optional[list[str]] = None,
@@ -162,7 +162,7 @@ def _get_images(
 
 def _get_labels(
     path: Path,
-    transformations: Mapping[str, Identity],
+    transformations: dict[str, Identity],
     imread_kwargs: Mapping[str, Any] = MappingProxyType({}),
     label_models_kwargs: Mapping[str, Any] = MappingProxyType({}),
 ) -> Union[SpatialImage, MultiscaleSpatialImage]:

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Union
 
+import anndata as ad
 import numpy as np
 import pandas as pd
 import yaml
@@ -113,6 +114,7 @@ def mcmicro(
             core_id = int(core_id_search.group()) if core_id_search else None
             labels[f"core_{core_id}_{segmentation_stem}"] = _get_labels(
                 label_path,
+                transformations,
                 imread_kwargs,
                 label_models_kwargs,
             )
@@ -178,7 +180,7 @@ def _get_table(
             if not adatas:
                 adatas = adata
             else:
-                adatas = adatas.concatenate(adata, index_unique=None)
+                adatas = ad.concat([adatas, adata], index_unique=None)
 
     return TableModel.parse(adatas, region=regions, region_key="region", instance_key=McmicroKeys.INSTANCE_KEY.value)
 

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -56,16 +56,16 @@ def mcmicro(
         tma = False
 
     if not tma:
-        image_dir = (path / McmicroKeys.IMAGES_DIR_WSI)
+        image_dir = path / McmicroKeys.IMAGES_DIR_WSI
         if not image_dir.exists():
             raise ValueError(f"{path} does not contain {McmicroKeys.IMAGES_DIR_WSI} directory")
 
-        samples = list(image_dir.glob('*' + McmicroKeys.IMAGE_SUFFIX))
+        samples = list(image_dir.glob("*" + McmicroKeys.IMAGE_SUFFIX))
         if len(samples) > 1:
             raise ValueError("Only one sample per dataset is supported.")
     else:
-        image_dir = (path / McmicroKeys.IMAGES_DIR_TMA)
-        samples = list(image_dir.glob('*' + McmicroKeys.IMAGE_SUFFIX))
+        image_dir = path / McmicroKeys.IMAGES_DIR_TMA
+        samples = list(image_dir.glob("*" + McmicroKeys.IMAGE_SUFFIX))
 
     images = {}
     for sample in samples:
@@ -79,22 +79,22 @@ def mcmicro(
         )
 
     labels = {}
-    labels[f"{dataset_id}_cells"] = _get_labels(
+    labels[f"{image_id}_cells"] = _get_labels(
         path,
-        dataset_id,
+        image_id,
         "cell",
         imread_kwargs,
         image_models_kwargs,
     )
-    labels[f"{dataset_id}_nuclei"] = _get_labels(
+    labels[f"{image_id}_nuclei"] = _get_labels(
         path,
-        dataset_id,
+        image_id,
         "nuclei",
         imread_kwargs,
         image_models_kwargs,
     )
 
-    table = _get_table(path, dataset_id)
+    table = _get_table(path, image_id)
 
     return SpatialData(images=images, labels=labels, table=table)
 

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -59,10 +59,6 @@ def mcmicro(
     ----------
     path
         Path to the dataset.
-    dataset_id
-        Dataset identifier.
-    tma
-        Whether output is from a tissue microarray analysis
     imread_kwargs
         Keyword arguments to pass to the image reader.
     image_models_kwargs

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -55,13 +55,8 @@ def mcmicro(
     :class:`spatialdata.SpatialData`
     """
     path = Path(path)
-    _load_params(path)
-
-    # Output directory dearray is specific for tissue micro array output of MCMICRO
-    if (path / McmicroKeys.IMAGES_DIR_TMA).exists():
-        tma = True
-    else:
-        tma = False
+    params = _load_params(path)
+    tma = params["workflow"]["tma"]
 
     if not tma:
         image_dir = path / McmicroKeys.IMAGES_DIR_WSI


### PR DESCRIPTION
This PR updates the code related to creating a SpatialData object out of MCMICRO output. In particular with this PR, tissue micro array output of MCMICRO is supported in addition to the WSI output. Also some code fixes for `exemplar_001` are included

One bug has been fixed when passing on image_models_kwargs. When passing dims, this led to problems as the same kwargs were used for the label model. While the image model for MCMICRO should have dims ```('c', 'y', 'x')``` the label model should have dims ```('y', 'x')```. 

For `tma` the config file is read to check whether the data refers to whole slide imaging or tissue micro array.

Currently, for transformations only `global` with an `Identity` transform is possible. This can change later. Furthermore, illumination images and dearray masks are now included in the `SpatialData` object.

Code has been tested on exemplar-001 and exemplar-002 output of MCMICRO.

