### PR TITLE
Update docs to point to spatialdata.scverse.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ If you found a bug, please use the [issue tracker][issue-tracker].
 
 [scverse-discourse]: https://discourse.scverse.org/
 [issue-tracker]: https://github.com/scverse/spatialdata-io/issues
-[changelog]: https://spatialdata-io.readthedocs.io/latest/changelog.html
-[link-docs]: https://spatialdata-io.readthedocs.io
-[link-api]: https://spatialdata-io.readthedocs.io/latest/api.html
+[changelog]: https://spatialdata.scverse.org/en/latest/changelog.html
+[link-docs]: https://spatialdata.scverse.org
+[link-api]: https://spatialdata.scverse.org/projects/io/en/latest/api.html

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ This package contains reader functions to load common spatial omics formats into
 -   Curio
 
 Coming soon:
-- Vizgen MERSCOPE (MERFISH)
-- Spatial Genomics seqFISH
+
+-   Vizgen MERSCOPE (MERFISH)
+-   Spatial Genomics seqFISH
 
 Also coming soon:
-- Common image converters: .jpg <> .zarr
+
+-   Common image converters: .jpg <> .zarr
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@
 This package contains reader functions to load common spatial omics formats into SpatialData. Currently, we provide support for:
 
 -   NanoString CosMx
--   MCMICRO
--   Steinbock
+-   MCMICRO (output data)
+-   Steinbock (output data)
 -   10x Genomics Visium
 -   10x Genomics Xenium
+-   Curio
+
+Coming soon:
+- Vizgen MERSCOPE (MERFISH)
+- Spatial Genomics seqFISH
+
+Also coming soon:
+- Common image converters: .jpg <> .zarr
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ If you found a bug, please use the [issue tracker][issue-tracker].
 
 [scverse-discourse]: https://discourse.scverse.org/
 [issue-tracker]: https://github.com/scverse/spatialdata-io/issues
-[changelog]: https://spatialdata.scverse.org/en/latest/changelog.html
-[link-docs]: https://spatialdata.scverse.org
+[changelog]: https://spatialdata.scverse.org/projects/io/en/latest/changelog.html
+[link-docs]: https://spatialdata.scverse.org/projects/io/en/latest/
 [link-api]: https://spatialdata.scverse.org/projects/io/en/latest/api.html


### PR DESCRIPTION
Current doc links (docs, api, changelog) point to https://spatialdata-io.readthedocs.io (now defunct?).
I've updated them to point to https://spatialdata.scverse.org working URLs.