### PR TITLE
Set rgb argument to auto-detect whether image channels are RGB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning][].
 
 -   (Xenium) added `dims` parameter for more control in `xenium_aligned_image()`
 
+### Fixed
+
+-   Passing `rgb=None` to image model parser, leading to 3-4 channel images being interpreted as RGB(A)
+
 ## [0.1.4] - 2024-08-07
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ urls.Documentation = "https://spatialdata-io.readthedocs.io/"
 urls.Source = "https://github.com/scverse/spatialdata-io"
 urls.Home-page = "https://github.com/scverse/spatialdata-io"
 dependencies = [
-    "spatialdata",
+    "spatialdata>=2.2.0",
     "scikit-image",
     "h5py",
     "joblib",

--- a/src/spatialdata_io/readers/_utils/_utils.py
+++ b/src/spatialdata_io/readers/_utils/_utils.py
@@ -18,8 +18,8 @@ try:
 
     NDArrayA = NDArray[Any]
 except (ImportError, TypeError):
-    NDArray = np.ndarray  # type: ignore[misc]
-    NDArrayA = np.ndarray  # type: ignore[misc]
+    NDArray = np.ndarray  # type: ignore[misc,unused-ignore]
+    NDArrayA = np.ndarray  # type: ignore[misc,unused-ignore]
 
 
 def _read_counts(

--- a/src/spatialdata_io/readers/codex.py
+++ b/src/spatialdata_io/readers/codex.py
@@ -80,6 +80,7 @@ def codex(
             "images": Image2DModel.parse(
                 image,
                 scale_factors=[2, 2],
+                rgb=None,
             )
         }
         sdata = SpatialData(images=images, shapes={str(region): shapes}, table=table)

--- a/src/spatialdata_io/readers/cosmx.py
+++ b/src/spatialdata_io/readers/cosmx.py
@@ -200,6 +200,7 @@ def cosmx(
                         "global_only_image": aff,
                     },
                     dims=("y", "x", "c"),
+                    rgb=None,
                     **image_models_kwargs,
                 )
                 images[f"{fov}_image"] = parsed_im

--- a/src/spatialdata_io/readers/mcmicro.py
+++ b/src/spatialdata_io/readers/mcmicro.py
@@ -91,7 +91,7 @@ def _get_images(
     image_models_kwargs: Mapping[str, Any] = MappingProxyType({}),
 ) -> Union[SpatialImage, MultiscaleSpatialImage]:
     image = imread(path / McmicroKeys.IMAGES_DIR / f"{sample}{McmicroKeys.IMAGE_SUFFIX}", **imread_kwargs)
-    return Image2DModel.parse(image, **image_models_kwargs)
+    return Image2DModel.parse(image, rgb=None, **image_models_kwargs)
 
 
 def _get_labels(

--- a/src/spatialdata_io/readers/merscope.py
+++ b/src/spatialdata_io/readers/merscope.py
@@ -168,6 +168,7 @@ def merscope(
             dims=("c", "y", "x"),
             transformations={"microns": microns_to_pixels.inverse()},
             c_coords=stainings,
+            rgb=True,
             **image_models_kwargs,
         )
         images[f"{dataset_id}_z{z_layer}"] = parsed_im

--- a/src/spatialdata_io/readers/steinbock.py
+++ b/src/spatialdata_io/readers/steinbock.py
@@ -97,7 +97,7 @@ def _get_images(
     image_models_kwargs: Mapping[str, Any] = MappingProxyType({}),
 ) -> Union[SpatialImage, MultiscaleSpatialImage]:
     image = imread(path / SteinbockKeys.IMAGES_DIR / f"{sample}{SteinbockKeys.IMAGE_SUFFIX}", **imread_kwargs)
-    return Image2DModel.parse(data=image, transformations={sample: Identity()}, **image_models_kwargs)
+    return Image2DModel.parse(data=image, transformations={sample: Identity()}, rgb=None, **image_models_kwargs)
 
 
 def _get_labels(

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -192,6 +192,7 @@ def visium(
                 full_image,
                 scale_factors=[2, 2, 2, 2],
                 transformations={"global": transform_original},
+                rgb=None,
                 **image_models_kwargs,
             )
         else:
@@ -201,13 +202,15 @@ def visium(
         image_hires = imread(path / VisiumKeys.IMAGE_HIRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)
         image_hires = DataArray(image_hires, dims=("c", "y", "x"), name=dataset_id)
         images[dataset_id + "_hires_image"] = Image2DModel.parse(
-            image_hires, transformations={"downscaled_hires": Identity()}
+            image_hires, transformations={"downscaled_hires": Identity()}, rgb=None
         )
     if (path / VisiumKeys.IMAGE_LOWRES_FILE).exists():
         image_lowres = imread(path / VisiumKeys.IMAGE_LOWRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)
         image_lowres = DataArray(image_lowres, dims=("c", "y", "x"), name=dataset_id)
         images[dataset_id + "_lowres_image"] = Image2DModel.parse(
-            image_lowres, transformations={"downscaled_lowres": Identity()}
+            image_lowres,
+            transformations={"downscaled_lowres": Identity()},
+            rgb=None,
         )
 
     return SpatialData(images=images, shapes=shapes, table=table)

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -216,5 +216,5 @@ def _get_images(
 ) -> SpatialImage | MultiscaleSpatialImage:
     image = imread(path / file, **imread_kwargs)
     return Image2DModel.parse(
-        image, transformations={"global": Identity()}, dims=("c", "y", "x"), **image_models_kwargs
+        image, transformations={"global": Identity()}, dims=("c", "y", "x"), rgb=None, **image_models_kwargs
     )


### PR DESCRIPTION
Following issue https://github.com/scverse/napari-spatialdata/issues/150, the logic to decide whether channels should be visualized as RGB has been moved from the viewer `napari-spatialdata` to the parser in [spatial-image](https://github.com/spatial-image/spatial-image/pull/21), which in the case of RGB sets channel names to `["r", "g", "b"]`. The default behavior of `to_spatial_image` is `rgb=False` (no change of channel names). That means in order to have the auto-detection as it was in the viewer, we now need to opt-in in the readers, either to auto-detect RGB (`rgb=None`) or explicitly enforce RGB (`rgb=True`).

This PR modifies readers to opt in for RGB detection, or explicitly set RGB (where the original data-format is known to always be RGB(A) with 3 or 4 channels).