### PR TITLE
Fixed visium() to support file counts without dataset_id

### DIFF
--- a/src/spatialdata_io/readers/_utils/_utils.py
+++ b/src/spatialdata_io/readers/_utils/_utils.py
@@ -29,7 +29,6 @@ def _read_counts(
 ) -> tuple[AnnData, str]:
     path = Path(path)
     if counts_file.endswith(".h5"):
-        print(counts_file)
         adata: AnnData = _read_10x_h5(path / counts_file, **kwargs)
         with File(path / counts_file, mode="r") as f:
             attrs = dict(f.attrs)
@@ -50,9 +49,8 @@ def _read_counts(
                 adata.uns["spatial"][library_id]["metadata"][key] = metadata
 
         return adata, library_id
-
     if library_id is None:
-        raise ValueError("Please explicitly specify library id.")
+        raise ValueError("Please explicitly specify `library id`.")
 
     if counts_file.endswith((".csv", ".txt")):
         adata = read_text(path / counts_file, **kwargs)

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -117,6 +117,7 @@ def visium(
                 f"`dataset_id: {dataset_id}` does not match `library_id: {library_id}`. `dataset_id: {dataset_id}` "
                 f"will be used to build SpatialData."
             )
+        library_id = dataset_id
     else:
         dataset_id = library_id
     assert dataset_id is not None

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -103,7 +103,7 @@ def visium(
     except IndexError as e:
         if counts_file is None:
             logger.error(
-                f"{e}. \nError is due to the fact that the library id could not be found, this is the case when the `counts_file` is `.mtx`.",
+                f"{e}. \nError is due to the fact that the library id could not be found, if the counts file is `.mtx` (or else), Please provide a `counts_file`.",
             )
             raise e
     assert counts_file is not None


### PR DESCRIPTION
I cleaned up a bit `visium()`, which now supports raw data that doesn't contain the `library_id` in the filename of the count file.

I tested it on:
- https://github.com/giovp/spatialdata-sandbox/tree/main/visium_io
- https://github.com/giovp/spatialdata-sandbox/tree/main/visium (which now uses `spatialdata-io` to construct the `SpatialData` object, thanks to https://github.com/giovp/spatialdata-sandbox/pull/31.
- https://github.com/giovp/spatialdata-sandbox/tree/main/visium_associated_xenium_io

@giovp can you please give a quick look?