### PR TITLE
fix visium axes ordering for many versions AND cytassist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __pycache__/
 
 # other
 _version.py
+.code-workspace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,11 @@ default_stages:
 minimum_pre_commit_version: 2.16.0
 repos:
     - repo: https://github.com/psf/black
-      rev: 23.10.1
+      rev: 23.11.0
       hooks:
           - id: black
     - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.0.3
+      rev: v3.1.0
       hooks:
           - id: prettier
     - repo: https://github.com/asottile/blacken-docs
@@ -23,7 +23,7 @@ repos:
       hooks:
           - id: isort
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.6.1
+      rev: v1.7.1
       hooks:
           - id: mypy
             additional_dependencies: [numpy]

--- a/src/spatialdata_io/readers/_utils/_utils.py
+++ b/src/spatialdata_io/readers/_utils/_utils.py
@@ -10,7 +10,7 @@ from h5py import File
 
 from spatialdata_io.readers._utils._read_10x_h5 import _read_10x_h5
 
-PathLike = Union[os.PathLike, str]
+PathLike = Union[os.PathLike, str]  # type:ignore[type-arg]
 
 try:
     from numpy.typing import NDArray


### PR DESCRIPTION
this is yet another fix to the ongoing struggle of the visium spaceranger output (See #51 )

Now this has been tested:
tested it on spaceranger versions
- [x] 1.1.0
- [x] 1.3.0
- [x] 2.0.0
- [x] 2.0.1

with following type of full res images
- [x] tif
- [x] jpg
- [x] png

AND
- [x] Cytassist

🤞 something tell me it's no the last one