### PR TITLE
fixed visium image shape parsing

### DIFF
--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -116,11 +116,13 @@ class VisiumKeys(ModeEnum):
     # images
     IMAGE_HIRES_FILE = "spatial/tissue_hires_image.png"
     IMAGE_LOWRES_FILE = "spatial/tissue_lowres_image.png"
+    CYTASSIST_IMAGE_FILE = "spatial/cytassist_image.tiff"
 
     # scalefactors
     SCALEFACTORS_FILE = "scalefactors_json.json"
     SCALEFACTORS_HIRES = "tissue_hires_scalef"
     SCALEFACTORS_LOWRES = "tissue_lowres_scalef"
+    SCALEFACTORS_REGIST_TARGET_IMG = "regist_target_img_scalef"
 
     # spots
     SPOTS_FILE_1 = "tissue_positions_list.csv"

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -116,13 +116,11 @@ class VisiumKeys(ModeEnum):
     # images
     IMAGE_HIRES_FILE = "spatial/tissue_hires_image.png"
     IMAGE_LOWRES_FILE = "spatial/tissue_lowres_image.png"
-    CYTASSIST_IMAGE_FILE = "spatial/cytassist_image.tiff"
 
     # scalefactors
     SCALEFACTORS_FILE = "scalefactors_json.json"
     SCALEFACTORS_HIRES = "tissue_hires_scalef"
     SCALEFACTORS_LOWRES = "tissue_lowres_scalef"
-    SCALEFACTORS_REGIST_TARGET_IMG = "regist_target_img_scalef"
 
     # spots
     SPOTS_FILE_1 = "tissue_positions_list.csv"

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -125,8 +125,8 @@ class VisiumKeys(ModeEnum):
     # spots
     SPOTS_FILE_1 = "tissue_positions_list.csv"
     SPOTS_FILE_2 = "tissue_positions.csv"
-    SPOTS_X = "pxl_row_in_fullres"
-    SPOTS_Y = "pxl_col_in_fullres"
+    SPOTS_X = "pxl_col_in_fullres"
+    SPOTS_Y = "pxl_row_in_fullres"
 
 
 @unique

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -158,10 +158,21 @@ def visium(
     coords = read_coords(tissue_positions_file)
 
     # to handle spaceranger_version < 2.0.0, where no column names are provided
-    # in fact, from spaceranger 2.0.0, the column names are provided in the file, and
-    # are "pxl_col_in_fullres", "pxl_row_in_fullres" are inverted.
+
+    # print(coords.columns)
+    # ##
+    # import matplotlib.pyplot as plt
+    #
+    # c = coords[coords[1] == True]
+    # plt.scatter(c[3].values, c[2].values)
+    # # plt.scatter(c['array_col'].values, c['array_row'].values)
+    # plt.show()
+    # plt.scatter(c[5].values, c[4].values)
+    # # plt.scatter(c['pxl_col_in_fullres'].values, c['pxl_row_in_fullres'].values)
+    # plt.show()
+    ##
     if "in_tissue" not in coords.columns:
-        coords.columns = ["in_tissue", "array_row", "array_col", "pxl_col_in_fullres", "pxl_row_in_fullres"]
+        coords.columns = ["in_tissue", "array_row", "array_col", "pxl_row_in_fullres", "pxl_col_in_fullres"]
 
     adata.obs = pd.merge(adata.obs, coords, how="left", left_index=True, right_index=True)
     coords = adata.obs[[VisiumKeys.SPOTS_X, VisiumKeys.SPOTS_Y]].values
@@ -213,11 +224,11 @@ def visium(
                 ImagePIL.MAX_IMAGE_PIXELS = imread_kwargs.pop("MAX_IMAGE_PIXELS")
             if fullres_image_file.suffix != ".btf":
                 im = imread(fullres_image_file, **imread_kwargs)
-                # print(_read_tiff_axes_metadata(fullres_image_file))
+                print(_read_tiff_axes_metadata(fullres_image_file))
             else:
                 # dask_image doesn't recognize .btf automatically
                 im = imread2(fullres_image_file, **imread_kwargs)
-                # print(_read_tiff_axes_metadata(fullres_image_file))
+                print(_read_tiff_axes_metadata(fullres_image_file))
             # Depending on the versions of the pipeline, the axes of the image file from the tiff data is ordered in
             # different ways; here let's implement a simple check on the shape to determine the axes ordering.
             # Note that a more robust check could be implemented; this could be the work of a future PR. Unfortunately,

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -32,6 +32,7 @@ def visium(
     dataset_id: str | None = None,
     counts_file: str = VisiumKeys.FILTERED_COUNTS_FILE,
     fullres_image_file: str | Path | None = None,
+    cytassist_image_file: str | Path | None = None,
     tissue_positions_file: str | Path | None = None,
     scalefactors_file: str | Path | None = None,
     imread_kwargs: Mapping[str, Any] = MappingProxyType({}),
@@ -69,6 +70,9 @@ def visium(
         conventions.
     fullres_image_file
         Path to the full-resolution image.
+    cytassist_image_file
+        Path to the cytassist image file, defaults to `None`. When available, this file is usually stored in
+        ``{vx.CYTASSIST_IMAGE_FILE!r}``.
     tissue_positions_file
         Path to the tissue positions file.
     scalefactors_file
@@ -218,37 +222,8 @@ def visium(
     if fullres_image_file is not None:
         fullres_image_file = path / Path(fullres_image_file)
         if fullres_image_file.exists():
-            if "MAX_IMAGE_PIXELS" in imread_kwargs:
-                from PIL import Image as ImagePIL
-
-                ImagePIL.MAX_IMAGE_PIXELS = imread_kwargs.pop("MAX_IMAGE_PIXELS")
-            if fullres_image_file.suffix != ".btf":
-                im = imread(fullres_image_file, **imread_kwargs)
-                print(_read_tiff_axes_metadata(fullres_image_file))
-            else:
-                # dask_image doesn't recognize .btf automatically
-                im = imread2(fullres_image_file, **imread_kwargs)
-                print(_read_tiff_axes_metadata(fullres_image_file))
-            # Depending on the versions of the pipeline, the axes of the image file from the tiff data is ordered in
-            # different ways; here let's implement a simple check on the shape to determine the axes ordering.
-            # Note that a more robust check could be implemented; this could be the work of a future PR. Unfortunately,
-            # the tif data does not (or does not always) have OME metadata, so even such more general parser could lead
-            # to edge cases that could be addressed by a more interoperable file format.
-            if len(im.shape) not in [3, 4]:
-                raise ValueError(f"Image shape {im.shape} is not supported.")
-            if len(im.shape) == 4:
-                if im.shape[0] == 1:
-                    im = im.squeeze(0)
-                else:
-                    raise ValueError(f"Image shape {im.shape} is not supported.")
-            if im.shape[0] in [2, 3, 4]:
-                full_image = im
-            elif im.shape[2] in [2, 3, 4]:
-                full_image = im.transpose(2, 0, 1)
-            else:
-                raise ValueError(f"Image shape {im.shape} is not supported.")
-
-            full_image = DataArray(full_image, dims=("c", "y", "x"))
+            image = read_image(fullres_image_file, imread_kwargs)
+            full_image = DataArray(image, dims=("c", "y", "x"))
             images[dataset_id + "_full_image"] = Image2DModel.parse(
                 full_image,
                 scale_factors=[2, 2, 2, 2],
@@ -257,6 +232,34 @@ def visium(
             )
         else:
             logger.warning(f"File {fullres_image_file} does not exist, skipping...")
+    if cytassist_image_file is not None:
+        cytassist_image_file = path / Path(cytassist_image_file)
+        if cytassist_image_file.exists():
+            image = read_image(cytassist_image_file, imread_kwargs)
+            cytassist_image = DataArray(image, dims=("c", "y", "x"))
+            ##
+            transform_cytassist = Scale(
+                np.array(
+                    [
+                        1
+                        / scalefactors[VisiumKeys.SCALEFACTORS_REGIST_TARGET_IMG]
+                        / scalefactors[VisiumKeys.SCALEFACTORS_HIRES],
+                        1
+                        / scalefactors[VisiumKeys.SCALEFACTORS_REGIST_TARGET_IMG]
+                        / scalefactors[VisiumKeys.SCALEFACTORS_LOWRES],
+                    ]
+                ),
+                axes=("y", "x"),
+            )
+            ##
+            images[dataset_id + "_cytassist_image"] = Image2DModel.parse(
+                cytassist_image,
+                scale_factors=[2, 2, 2, 2],
+                transformations={"global": transform_cytassist},
+                **image_models_kwargs,
+            )
+        else:
+            logger.warning(f"File {cytassist_image_file} does not exist, skipping...")
 
     if (path / VisiumKeys.IMAGE_HIRES_FILE).exists():
         image_hires = imread(path / VisiumKeys.IMAGE_HIRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)
@@ -279,3 +282,36 @@ def _read_tiff_axes_metadata(tiff_file: Path) -> Any:
 
     with TiffFile(tiff_file) as tif:
         return tif.pages[0].axes
+
+
+def read_image(image_file: Path, imread_kwargs) -> Any:
+    if "MAX_IMAGE_PIXELS" in imread_kwargs:
+        from PIL import Image as ImagePIL
+
+        ImagePIL.MAX_IMAGE_PIXELS = imread_kwargs.pop("MAX_IMAGE_PIXELS")
+    if image_file.suffix != ".btf":
+        im = imread(image_file, **imread_kwargs)
+        print(_read_tiff_axes_metadata(image_file))
+    else:
+        # dask_image doesn't recognize .btf automatically
+        im = imread2(image_file, **imread_kwargs)
+        print(_read_tiff_axes_metadata(image_file))
+        # Depending on the versions of the pipeline, the axes of the image file from the tiff data is ordered in
+        # different ways; here let's implement a simple check on the shape to determine the axes ordering.
+        # Note that a more robust check could be implemented; this could be the work of a future PR. Unfortunately,
+        # the tif data does not (or does not always) have OME metadata, so even such more general parser could lead
+        # to edge cases that could be addressed by a more interoperable file format.
+    if len(im.shape) not in [3, 4]:
+        raise ValueError(f"Image shape {im.shape} is not supported.")
+    if len(im.shape) == 4:
+        if im.shape[0] == 1:
+            im = im.squeeze(0)
+        else:
+            raise ValueError(f"Image shape {im.shape} is not supported.")
+    if im.shape[0] in [2, 3, 4]:
+        image = im
+    elif im.shape[2] in [2, 3, 4]:
+        image = im.transpose(2, 0, 1)
+    else:
+        raise ValueError(f"Image shape {im.shape} is not supported.")
+    return image

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -160,9 +160,7 @@ def visium(
     # to handle spaceranger_version < 2.0.0, where no column names are provided
     # in fact, from spaceranger 2.0.0, the column names are provided in the file, and
     # are "pxl_col_in_fullres", "pxl_row_in_fullres" are inverted.
-    # But, in the case of CytAssist, the column names provided but the image is flipped
-    # so we need to invert the columns.
-    if "in_tissue" not in coords.columns or "CytAssist" in str(fullres_image_file):
+    if "in_tissue" not in coords.columns:
         coords.columns = ["in_tissue", "array_row", "array_col", "pxl_col_in_fullres", "pxl_row_in_fullres"]
 
     adata.obs = pd.merge(adata.obs, coords, how="left", left_index=True, right_index=True)
@@ -215,9 +213,11 @@ def visium(
                 ImagePIL.MAX_IMAGE_PIXELS = imread_kwargs.pop("MAX_IMAGE_PIXELS")
             if fullres_image_file.suffix != ".btf":
                 im = imread(fullres_image_file, **imread_kwargs)
+                # print(_read_tiff_axes_metadata(fullres_image_file))
             else:
                 # dask_image doesn't recognize .btf automatically
                 im = imread2(fullres_image_file, **imread_kwargs)
+                # print(_read_tiff_axes_metadata(fullres_image_file))
             # Depending on the versions of the pipeline, the axes of the image file from the tiff data is ordered in
             # different ways; here let's implement a simple check on the shape to determine the axes ordering.
             # Note that a more robust check could be implemented; this could be the work of a future PR. Unfortunately,
@@ -261,3 +261,10 @@ def visium(
         )
 
     return SpatialData(images=images, shapes=shapes, table=table)
+
+
+def _read_tiff_axes_metadata(tiff_file: Path) -> Any:
+    from tifffile import TiffFile
+
+    with TiffFile(tiff_file) as tif:
+        return tif.pages[0].axes


### PR DESCRIPTION
Fix wrong aligned of Visium H&E images with Visium circular capture locations. This bug was affecting only specific versions. 

Also, added support for immunofluerence images and big tif images.