### PR TITLE
CosMX reader with stitching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.1.3] - xxxx-xx-xx
 
-
 ## [0.1.2] - 2024-03-30
 
 ### Added

--- a/src/spatialdata_io/readers/cosmx.py
+++ b/src/spatialdata_io/readers/cosmx.py
@@ -138,7 +138,7 @@ def _infer_dataset_id(path: Path, dataset_id: str | None) -> str:
         counts_files = list(path.rglob(f"*_fov_positions_file{suffix}"))
 
         if len(counts_files) == 1:
-            found = re.match(rf"(.*)_fov_positions_file{suffix}", str(counts_files[0]))
+            found = re.match(rf"(.*)_fov_positions_file{suffix}", counts_files[0].name)
             if found:
                 return found.group(1)
 


### PR DESCRIPTION
Adding stitching to the CosMX reader. It's also possible to load one FOV only (if desired), and reading the proteins has also been added.

This is still a very early version of the reader, and it lacks the things below, but I made the PR so that we can start a discussion.
- [ ] Update CHANGELOG
- [ ] Add all constants in `CosmxKeys`
- [ ] Add labels to the `SpatialData` object
- [ ] Update the docstrings (this current docstrings were copy-pasted from Sopa)
- [ ] Adding some tests?