### PR TITLE
Fixed path searching behavior in DBiT reader.

### DIFF
--- a/src/spatialdata_io/readers/dbit.py
+++ b/src/spatialdata_io/readers/dbit.py
@@ -85,9 +85,9 @@ def _check_path(
                 flag = True
 
             except IndexError:
-                raise IndexError(f'There are no files in {path} matching {key}.')
-    
-    logger.warning(f'{file_path} is used.')
+                raise IndexError(f"There are no files in {path} matching {key}.")
+
+    logger.warning(f"{file_path} is used.")
 
     return file_path, flag
 
@@ -264,13 +264,17 @@ def dbit(
     # search for files paths. Gives priority to files matching the pattern found in path.
     anndata_path_checked = _check_path(
         path=path, path_specific=anndata_path, pattern=patt_h5ad, key=DbitKeys.COUNTS_FILE
-    )[0] # type: ignore
+    )[
+        0
+    ]  # type: ignore
     barcode_position_checked = _check_path(
         path=path, path_specific=barcode_position, pattern=patt_barcode, key=DbitKeys.BARCODE_POSITION
-    )[0] # type: ignore
+    )[
+        0
+    ]  # type: ignore
     image_path_checked, hasimage = _check_path(
         path=path,
-        path_specific=image_path, # type: ignore
+        path_specific=image_path,  # type: ignore
         pattern=patt_lowres,
         key=DbitKeys.IMAGE_LOWRES_FILE,
         optional_arg=True,

--- a/src/spatialdata_io/readers/dbit.py
+++ b/src/spatialdata_io/readers/dbit.py
@@ -43,7 +43,7 @@ def _check_path(
         String to match in the path or path_specific path.
     path_specific
         path to the file, if it is not in the main directory.
-        If it is given and valid, this is used and 'path' is neglected.        
+        If it is given and valid, this is used and 'path' is neglected.
     optional_arg : bool, optional
         User specify if the file to search is:
             mandatory:  (optional_arg=False, raise an Error if not found)
@@ -88,7 +88,7 @@ def _check_path(
         if len(matches) > 1:
             if optional_arg:
                 logger.warning(
-                    f'There are {len(matches)} file matching {key} in {Path(path)}. Specify the correct file path to avoid ambiguities.'
+                    f"There are {len(matches)} file matching {key} in {Path(path)}. Specify the correct file path to avoid ambiguities."
                 )
                 return file_path, flag
             else:
@@ -357,7 +357,7 @@ def dbit(
     ra = shapely.to_ragged_array([shapely.Polygon(x) for x in f])
     grid = sd.models.ShapesModel.parse(ra[1], geometry=ra[0], offsets=ra[2], index=adata.obs["pixel_id"].copy())
     # create SpatialData object!
-    sdata = sd.SpatialData(tables={'table':table_data}, shapes={dataset_id: grid})
+    sdata = sd.SpatialData(tables={"table": table_data}, shapes={dataset_id: grid})
     if hasimage:
         imgname = dataset_id + "_image"
         sdata.images[imgname] = image_sd

--- a/src/spatialdata_io/readers/dbit.py
+++ b/src/spatialdata_io/readers/dbit.py
@@ -44,7 +44,7 @@ def _check_path(
     path_specific
         path to the file, if it is not in the main directory.
         If it is given and valid, this is used and 'path' is neglected.
-    optional_arg : bool, optional
+    optional_arg
         User specify if the file to search is:
             mandatory:  (optional_arg=False, raise an Error if not found)
             optional:   (optional_arg=True, raise a Warning if not found).
@@ -86,15 +86,12 @@ def _check_path(
         # search for the pattern matching file in path
         matches = [i for i in os.listdir(path) if pattern.match(i)]
         if len(matches) > 1:
+            message = f"There are {len(matches)} file matching {key} in {Path(path)}. Specify the correct file path to avoid ambiguities."
             if optional_arg:
-                logger.warning(
-                    f"There are {len(matches)} file matching {key} in {Path(path)}. Specify the correct file path to avoid ambiguities."
-                )
+                logger.warning(message)
                 return file_path, flag
             else:
-                raise Exception(
-                    f"There are {len(matches)} file matching {key} in {Path(path)}. Specify the correct file path to avoid ambiguities."
-                )
+                raise Exception(message)
         else:
             # if there is a matching file, use it
             try:

--- a/src/spatialdata_io/readers/dbit.py
+++ b/src/spatialdata_io/readers/dbit.py
@@ -263,18 +263,18 @@ def dbit(
 
     # search for files paths. Gives priority to files matching the pattern found in path.
     anndata_path_checked = _check_path(
-        path=path, path_specific=anndata_path, pattern=patt_h5ad, key=DbitKeys.COUNTS_FILE
-    )[
-        0
-    ]  # type: ignore
+        path=path,  # type: ignore
+        path_specific=anndata_path,
+        pattern=patt_h5ad,
+        key=DbitKeys.COUNTS_FILE)[0]  
     barcode_position_checked = _check_path(
-        path=path, path_specific=barcode_position, pattern=patt_barcode, key=DbitKeys.BARCODE_POSITION
-    )[
-        0
-    ]  # type: ignore
+        path=path,  # type: ignore
+        path_specific=barcode_position,
+        pattern=patt_barcode,
+        key=DbitKeys.BARCODE_POSITION)[0]  
     image_path_checked, hasimage = _check_path(
-        path=path,
-        path_specific=image_path,  # type: ignore
+        path=path,  # type: ignore
+        path_specific=image_path,
         pattern=patt_lowres,
         key=DbitKeys.IMAGE_LOWRES_FILE,
         optional_arg=True,

--- a/src/spatialdata_io/readers/dbit.py
+++ b/src/spatialdata_io/readers/dbit.py
@@ -100,11 +100,12 @@ def _check_path(
                 flag = True
             # if there are no files matching the pattern, raise error
             except IndexError:
+                message = f"There are no files in {path} matching {key}."
                 if optional_arg:
-                    logger.warning(f"There are no files in {path} matching {key}.")
+                    logger.warning(message)
                     return file_path, flag
                 else:
-                    raise IndexError(f"There are no files in {path} matching {key}.")
+                    raise IndexError(message)
 
     logger.warning(f"{file_path} is used.")
     return file_path, flag

--- a/src/spatialdata_io/readers/dbit.py
+++ b/src/spatialdata_io/readers/dbit.py
@@ -81,7 +81,7 @@ def _check_path(
                 checked_file = [i for i in os.listdir(path) if pattern.match(i)][0]  # this is the filename
                 file_path = Path.joinpath(path, checked_file)
                 flag = True
-            except:
+            except IndexError:
                 raise IndexError(f'There are no files in {path} matching {key}.')
     
     logger.warning(f'{file_path} is used.')
@@ -261,13 +261,13 @@ def dbit(
     # search for files paths. Gives priority to files matching the pattern found in path.
     anndata_path_checked = _check_path(
         path=path, path_specific=anndata_path, pattern=patt_h5ad, key=DbitKeys.COUNTS_FILE
-    )[0]
+    )[0] # type: ignore
     barcode_position_checked = _check_path(
         path=path, path_specific=barcode_position, pattern=patt_barcode, key=DbitKeys.BARCODE_POSITION
-    )[0]
+    )[0] # type: ignore
     image_path_checked, hasimage = _check_path(
         path=path,
-        path_specific=image_path,
+        path_specific=image_path, # type: ignore
         pattern=patt_lowres,
         key=DbitKeys.IMAGE_LOWRES_FILE,
         optional_arg=True,

--- a/src/spatialdata_io/readers/dbit.py
+++ b/src/spatialdata_io/readers/dbit.py
@@ -263,15 +263,11 @@ def dbit(
 
     # search for files paths. Gives priority to files matching the pattern found in path.
     anndata_path_checked = _check_path(
-        path=path,  # type: ignore
-        path_specific=anndata_path,
-        pattern=patt_h5ad,
-        key=DbitKeys.COUNTS_FILE)[0]  
+        path=path, path_specific=anndata_path, pattern=patt_h5ad, key=DbitKeys.COUNTS_FILE  # type: ignore
+    )[0]
     barcode_position_checked = _check_path(
-        path=path,  # type: ignore
-        path_specific=barcode_position,
-        pattern=patt_barcode,
-        key=DbitKeys.BARCODE_POSITION)[0]  
+        path=path, path_specific=barcode_position, pattern=patt_barcode, key=DbitKeys.BARCODE_POSITION  # type: ignore
+    )[0]
     image_path_checked, hasimage = _check_path(
         path=path,  # type: ignore
         path_specific=image_path,


### PR DESCRIPTION
With this update we change the behavior of the [DBiT reader](https://github.com/scverse/spatialdata-io/blob/main/src/spatialdata_io/readers/dbit.py) in paths selection and prioritization.

Specifically, the argument `path` of the function `spatialdata-io.readers.dbit.dbit()` is now optional.\
If paths to files are given with the specific arguments `anndata_path`, `barcode_position` or `image_path`, ***these are selected***, while matching files in the `path` directory are ignored.\
In the old behavior, the matching files in the `path` directory were prioritized, leading to ambiguities when a file path was given, and when multiple pattern matching files were found in the `path` directory.

#### Major changes
- The file path `anndata_path`, `barcode_position` or `image_path` is now always selected if given.
- An Error is now raised if multiple matching files are found in `path`.