### PR TITLE
Support for `binned_ouputs` folder for Visium HD

### DIFF
--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -315,6 +315,7 @@ class VisiumHDKeys(ModeEnum):
     DEFAULT_BIN = "square_008um"
     BIN_PREFIX = "square_"
     MICROSCOPE_IMAGE = "microscope_image"
+    BINNED_OUTPUTS = "binned_outputs"
 
     # counts and locations files
     FILTERED_COUNTS_FILE = "filtered_feature_bc_matrix.h5"

--- a/src/spatialdata_io/readers/cosmx.py
+++ b/src/spatialdata_io/readers/cosmx.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 from anndata import AnnData
-from dask.dataframe.core import DataFrame as DaskDataFrame
+from dask.dataframe import DataFrame as DaskDataFrame
 from dask_image.imread import imread
 from scipy.sparse import csr_matrix
 

--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -113,14 +113,21 @@ def visium_hd(
             stacklevel=2,
         )
 
-    path_bins = path
-    all_bin_sizes = sorted(
-        [
-            bin_size
-            for bin_size in os.listdir(path_bins)
-            if os.path.isdir(os.path.join(path_bins, bin_size)) and bin_size.startswith(VisiumHDKeys.BIN_PREFIX)
-        ]
-    )
+    def _get_bins(path: Path) -> list[str]:
+        return sorted(
+            [
+                bin_size
+                for bin_size in os.listdir(path)
+                if os.path.isdir(os.path.join(path, bin_size)) and bin_size.startswith(VisiumHDKeys.BIN_PREFIX)
+            ]
+        )
+
+    if VisiumHDKeys.BINNED_OUTPUTS in os.listdir(path):
+        path_bins = path / VisiumHDKeys.BINNED_OUTPUTS
+    else:
+        path_bins = path
+    all_bin_sizes = _get_bins(path_bins)
+
     if bin_size is None:
         bin_sizes = all_bin_sizes
     elif isinstance(bin_size, int) or isinstance(bin_size, list) and len(bin_size) == 0:


### PR DESCRIPTION
A user reported that the data generated by spaceranger was organized differently: with the bins inside the folder `binned_outputs`. https://github.com/scverse/spatialdata/issues/563

Now the readers checks if this folder exists, and parse the bin data form the appropriate location.