### PR TITLE
Add tifffile to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "dask-image",
     "pyarrow",
     "readfcs",
+    "tifffile>=2023.8.12",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #174

Add `tifffile` to the project dependencies in `pyproject.toml`.

* Specify the minimum version of `tifffile` as `2023.8.12`.