### PR TITLE
Fix xenium default value and add deprecation warning

### DIFF
--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -56,7 +56,7 @@ def xenium(
     *,
     cells_boundaries: bool = True,
     nucleus_boundaries: bool = True,
-    cells_as_circles: bool = False,
+    cells_as_circles: bool = None,
     cells_labels: bool = True,
     nucleus_labels: bool = True,
     transcripts: bool = True,
@@ -146,6 +146,14 @@ def xenium(
     ... )
     >>> sdata.write("path/to/data.zarr")
     """
+    if cells_as_circles is None:
+        cells_as_circles = True
+        warnings.warn(
+            "The default value of `cells_as_circles` will change to `False` in the next release. "
+            "Please pass `True` explicitly to maintain the current behavior.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     image_models_kwargs, labels_models_kwargs = _initialize_raster_models_kwargs(
         image_models_kwargs, labels_models_kwargs
     )

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -152,7 +152,7 @@ def xenium(
             "The default value of `cells_as_circles` will change to `False` in the next release. "
             "Please pass `True` explicitly to maintain the current behavior.",
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
     image_models_kwargs, labels_models_kwargs = _initialize_raster_models_kwargs(
         image_models_kwargs, labels_models_kwargs

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -56,7 +56,7 @@ def xenium(
     *,
     cells_boundaries: bool = True,
     nucleus_boundaries: bool = True,
-    cells_as_circles: bool = None,
+    cells_as_circles: bool | None = None,
     cells_labels: bool = True,
     nucleus_labels: bool = True,
     transcripts: bool = True,

--- a/tests/test_xenium.py
+++ b/tests/test_xenium.py
@@ -57,7 +57,7 @@ def test_roundtrip_with_data_limits() -> None:
 def test_example_data(dataset: str, expected: str) -> None:
     f = Path("./data") / dataset
     assert f.is_dir()
-    sdata = xenium(f)
+    sdata = xenium(f, cells_as_circles=False)
     from spatialdata import get_extent
 
     extent = get_extent(sdata, exact=False)


### PR DESCRIPTION
This PR is AI generated (Copilot Workspace).

Related to #184

Revert the default value of `cells_as_circles` to `True` and add a deprecation warning.

* Change the default value of the `cells_as_circles` parameter to `None` in the `xenium` function.
* Add a deprecation warning indicating that the default will change to `False` in the next release.
* Add logic to set `cells_as_circles` to `True` if it is `None` and display the deprecation warning.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/scverse/spatialdata-io/issues/184?shareId=20adda91-8a95-4446-b213-c197ce8f925b).