### PR TITLE
added dims paramter to xenium_aligned_image()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.1.4] - xxxx-xx-xx
 
+### Added
+
+-   (Xenium) added `dims` parameter for more control in `xenium_aligned_image()`
+
 ## [0.1.4] - 2024-08-07
 
 ### Changed


### PR DESCRIPTION
Closes #168 

Added the `dims` parameter to give control on the axis names of the additional images. Useful when the default heuristic used to infer the dims fails, as in #168.

Here is an example on how to use the new functionality; please notice that you need to pass `aligned_images=False` to `xenium()`.

```python
##
from pathlib import Path

# data from here https://github.com/giovp/spatialdata-sandbox/tree/main/xenium_2.0.0_io
f = Path("spatialdata-sandbox/xenium_2.0.0_io/data")

from spatialdata_io import xenium, xenium_aligned_image

sdata = xenium(path=f, aligned_images=False)

image_path = f / "Xenium_V1_humanLung_Cancer_FFPE_he_image.ome.tif"
alignment_file_path = f / "Xenium_V1_humanLung_Cancer_FFPE_he_imagealignment.csv"
sdata["my_if_image"] = xenium_aligned_image(
    image_path=image_path,
    alignment_file=alignment_file_path,
    image_models_kwargs={"scale_factors": [2, 2, 2]},
    dims=("k", "y", "x", "c"),
)

# you need to save the data and re-read it to take advantage of the Zarr optimization
# sdata.write('data.zarr')
# import spatialdata as sd
# sdata = sd.read_zarr('data.zarr')

``` 