### PR TITLE
adjust for crc2 dataset

### DIFF
--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -353,9 +353,9 @@ class VisiumHDKeys(ModeEnum):
     TISSUE_POSITIONS_FILE = "tissue_positions.parquet"
 
     # images
-    IMAGE_HIRES_FILE = "spatial/tissue_hires_image.png"
-    IMAGE_LOWRES_FILE = "spatial/tissue_lowres_image.png"
-    IMAGE_CYTASSIST = "spatial/cytassist_image.tiff"
+    IMAGE_HIRES_FILE = "tissue_hires_image.png"
+    IMAGE_LOWRES_FILE = "tissue_lowres_image.png"
+    IMAGE_CYTASSIST = "cytassist_image.tiff"
 
     # scalefactors
     SCALEFACTORS_FILE = "scalefactors_json.json"

--- a/src/spatialdata_io/readers/_utils/_utils.py
+++ b/src/spatialdata_io/readers/_utils/_utils.py
@@ -18,8 +18,8 @@ try:
 
     NDArrayA = NDArray[Any]
 except (ImportError, TypeError):
-    NDArray = np.ndarray  # type: ignore[misc]
-    NDArrayA = np.ndarray  # type: ignore[misc]
+    NDArray = np.ndarray
+    NDArrayA = np.ndarray
 
 
 def _read_counts(

--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -292,9 +292,11 @@ def visium_hd(
         )
 
     # hires image
-    hires_image_path = [path for path in all_files if VisiumHDKeys.IMAGE_HIRES_FILE in str(path)][0]
+    hires_image_path = [path for path in all_files if VisiumHDKeys.IMAGE_HIRES_FILE in str(path)]
+    if len(hires_image_path) == 0:
+        raise OSError(f"No image path found containing the hires image: {VisiumHDKeys.IMAGE_HIRES_FILE}")
     load_image(
-        path=hires_image_path,
+        path=hires_image_path[0],
         suffix="_hires_image",
     )
     set_transformation(
@@ -304,13 +306,11 @@ def visium_hd(
     )
 
     # lowres image
-    lowres_image_path = [path for path in all_files if VisiumHDKeys.IMAGE_LOWRES_FILE in str(path)][0]
+    lowres_image_path = [path for path in all_files if VisiumHDKeys.IMAGE_LOWRES_FILE in str(path)]
+    if len(lowres_image_path) == 0:
+        raise OSError(f"No image path found containing the lowres image: {VisiumHDKeys.IMAGE_LOWRES_FILE}")
     load_image(
-        path=(
-            lowres_image_path
-            if lowres_image_path.exists()
-            else path / f"{filename_prefix}spatial" / VisiumHDKeys.IMAGE_LOWRES_FILE
-        ),
+        path=lowres_image_path[0],
         suffix="_lowres_image",
     )
     set_transformation(
@@ -320,14 +320,12 @@ def visium_hd(
     )
 
     # cytassist image
-    cytassist_path = [path for path in all_files if VisiumHDKeys.IMAGE_CYTASSIST in str(path)][0]
+    cytassist_path = [path for path in all_files if VisiumHDKeys.IMAGE_CYTASSIST in str(path)]
+    if len(cytassist_path) == 0:
+        raise OSError(f"No image path found containing the cytassist image: {VisiumHDKeys.IMAGE_CYTASSIST}")
     if load_all_images:
         load_image(
-            path=(
-                cytassist_path
-                if cytassist_path.exists()
-                else path / f"{filename_prefix}spatial" / VisiumHDKeys.IMAGE_CYTASSIST
-            ),
+            path=cytassist_path[0],
             suffix="_cytassist_image",
         )
         image = images[dataset_id + "_cytassist_image"]

--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -86,6 +86,7 @@ def visium_hd(
     SpatialData object for the Visium HD data.
     """
     path = Path(path)
+    all_files = [file for file in path.rglob("*") if file.is_file()]
     tables = {}
     shapes = {}
     images: dict[str, Any] = {}
@@ -291,13 +292,9 @@ def visium_hd(
         )
 
     # hires image
-    hires_image_path = path / VisiumHDKeys.IMAGE_HIRES_FILE
+    hires_image_path = [path for path in all_files if VisiumHDKeys.IMAGE_HIRES_FILE in str(path)][0]
     load_image(
-        path=(
-            hires_image_path
-            if hires_image_path.exists()
-            else path / f"{filename_prefix}spatial" / VisiumHDKeys.IMAGE_HIRES_FILE
-        ),
+        path=hires_image_path,
         suffix="_hires_image",
     )
     set_transformation(
@@ -307,7 +304,7 @@ def visium_hd(
     )
 
     # lowres image
-    lowres_image_path = path / VisiumHDKeys.IMAGE_LOWRES_FILE
+    lowres_image_path = [path for path in all_files if VisiumHDKeys.IMAGE_LOWRES_FILE in str(path)][0]
     load_image(
         path=(
             lowres_image_path
@@ -323,7 +320,7 @@ def visium_hd(
     )
 
     # cytassist image
-    cytassist_path = path / VisiumHDKeys.IMAGE_CYTASSIST
+    cytassist_path = [path for path in all_files if VisiumHDKeys.IMAGE_CYTASSIST in str(path)][0]
     if load_all_images:
         load_image(
             path=(

--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -126,8 +126,12 @@ def visium_hd(
             ]
         )
 
-    if VisiumHDKeys.BINNED_OUTPUTS in os.listdir(path):
-        path_bins = path / VisiumHDKeys.BINNED_OUTPUTS
+    all_path_bins = [path_bin for path_bin in all_files if VisiumHDKeys.BINNED_OUTPUTS in str(path_bin)]
+    if len(all_path_bins) != 0:
+        path_bins_parts = all_path_bins[
+            -1
+        ].parts  # just choosing last one here as users might have tar file which would be first
+        path_bins = Path(*path_bins_parts[: path_bins_parts.index(VisiumHDKeys.BINNED_OUTPUTS) + 1])
     else:
         path_bins = path
     all_bin_sizes = _get_bins(path_bins)


### PR DESCRIPTION
When reading in the data from https://www.10xgenomics.com/products/visium-hd-spatial-gene-expression/dataset-human-crc a few problems were encountered. First, the `lowres`, `hires` etc images were located in a directory with as root level the `dataset_id` prefix followed by spatial which then contained the `spatial` directory. Furthermore the naming of the fullres image was different. This PR accounts for that.