### PR TITLE
MERSCOPE: adding feature_key attribute for points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
-## [0.1.4] - xxxx-xx-xx
+## [0.1.6] - xxxx-xx-xx
+-   (MERSCOPE) added `feature_key` attribute for points (i.e., the `'gene'` column) #210
+
+## [0.1.5] - 2024-09-25
 
 ### Added
 
 -   (Xenium) added `dims` parameter for more control in `xenium_aligned_image()`
--   (MERSCOPE) added `feature_key` attribute for points (i.e., the `'gene'` column)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning][].
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
 ## [0.1.6] - xxxx-xx-xx
+
 -   (MERSCOPE) added `feature_key` attribute for points (i.e., the `'gene'` column) #210
 
 ## [0.1.5] - 2024-09-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning][].
 ### Added
 
 -   (Xenium) added `dims` parameter for more control in `xenium_aligned_image()`
-
+-   (MERSCOPE) added `feature_key` attribute for points (i.e., the `'gene'` column)
 ### Fixed
 
 -   Passing `rgb=None` to image model parser for both visium and visiumhd, leading to 3-4 channel images being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning][].
 
 -   (Xenium) added `dims` parameter for more control in `xenium_aligned_image()`
 -   (MERSCOPE) added `feature_key` attribute for points (i.e., the `'gene'` column)
+
 ### Fixed
 
 -   Passing `rgb=None` to image model parser for both visium and visiumhd, leading to 3-4 channel images being

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -322,6 +322,7 @@ class MerscopeKeys(ModeEnum):
     GLOBAL_Z = "global_z"
     Z_INDEX = "ZIndex"
     REGION_KEY = "cells_region"
+    GENE_KEY = "gene"
 
 
 @unique

--- a/src/spatialdata_io/readers/merscope.py
+++ b/src/spatialdata_io/readers/merscope.py
@@ -303,6 +303,7 @@ def _get_points(transcript_path: Path, transformations: dict[str, BaseTransforma
         transcript_df,
         coordinates={"x": MerscopeKeys.GLOBAL_X, "y": MerscopeKeys.GLOBAL_Y},
         transformations=transformations,
+        feature_key=MerscopeKeys.GENE_KEY,
     )
     transcripts["gene"] = transcripts["gene"].astype("category")
     return transcripts


### PR DESCRIPTION
Minor (but useful) PR: simply passing `"gene"` to the `feature_key` argument when parsing the points.