### PR TITLE
Visium hd

### DIFF
--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -370,24 +370,24 @@ def visium_hd(
             # add labels layer (rasterized bins).
             labels_name = f"{dataset_id}_{bin_size_str}_labels"
 
-            labels_element=rasterize_bins(
+            labels_element = rasterize_bins(
                 sdata,
-                bins = shapes_name, 
+                bins=shapes_name,
                 table_name=bin_size_str,
                 row_key=VisiumHDKeys.ARRAY_ROW,
-                col_key= VisiumHDKeys.ARRAY_COL,
+                col_key=VisiumHDKeys.ARRAY_COL,
                 value_key=None,
                 return_region_as_labels=True,
-                )
-            
-            sdata[ labels_name ] = labels_element
+            )
 
-            adata = sdata[ bin_size_str ]
+            sdata[labels_name] = labels_element
+
+            adata = sdata[bin_size_str]
 
             adata.obs[VisiumHDKeys.REGION_KEY] = labels_name
             adata.obs[VisiumHDKeys.REGION_KEY] = adata.obs[VisiumHDKeys.REGION_KEY].astype("category")
 
-            del adata.uns[ TableModel.ATTRS_KEY ]
+            del adata.uns[TableModel.ATTRS_KEY]
 
             adata = TableModel.parse(
                 adata,
@@ -396,8 +396,8 @@ def visium_hd(
                 instance_key=str(VisiumHDKeys.INSTANCE_KEY),
             )
 
-            del sdata[ bin_size_str ]
-            sdata[ bin_size_str ] = adata
+            del sdata[bin_size_str]
+            sdata[bin_size_str] = adata
 
     return sdata
 

--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -27,6 +27,7 @@ from spatialdata.transformations import (
     Sequence,
     set_transformation,
 )
+from spatialdata.models._utils import _get_uint_dtype
 from xarray import DataArray
 
 from spatialdata_io._constants._constants import VisiumHDKeys
@@ -474,19 +475,3 @@ def _get_transform_matrices(metadata: dict[str, Any], hd_layout: dict[str, Any])
         transform_matrices[key.value] = _get_affine(data)
 
     return transform_matrices
-
-
-def _get_uint_dtype(value: int) -> str:
-    max_uint64 = np.iinfo(np.uint64).max
-    max_uint32 = np.iinfo(np.uint32).max
-    max_uint16 = np.iinfo(np.uint16).max
-
-    if max_uint16 >= value:
-        dtype = "uint16"
-    elif max_uint32 >= value:
-        dtype = "uint32"
-    elif max_uint64 >= value:
-        dtype = "uint64"
-    else:
-        raise ValueError(f"Maximum cell number is {value}. Values higher than {max_uint64} are not supported.")
-    return dtype

--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -20,7 +20,6 @@ from numpy.random import default_rng
 from spatial_image import SpatialImage
 from spatialdata import SpatialData, rasterize_bins, rasterize_bins_link_table_to_labels
 from spatialdata.models import Image2DModel, ShapesModel, TableModel
-from spatialdata.models._utils import _get_uint_dtype
 from spatialdata.transformations import (
     Affine,
     Identity,
@@ -377,7 +376,9 @@ def visium_hd(
             )
 
             sdata[labels_name] = labels_element
-            rasterize_bins_link_table_to_labels(sdata=sdata, table_name=bin_size_str, labels_name=labels_name)
+            rasterize_bins_link_table_to_labels(
+                sdata=sdata, table_name=bin_size_str, rasterized_labels_name=labels_name
+            )
 
     return sdata
 

--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -42,9 +42,9 @@ def visium_hd(
     filtered_counts_file: bool = True,
     bin_size: int | list[int] | None = None,
     bins_as_squares: bool = True,
+    annotate_table_by_labels: bool = False,
     fullres_image_file: str | Path | None = None,
     load_all_images: bool = False,
-    annotate_table_by_labels: bool = False,
     imread_kwargs: Mapping[str, Any] = MappingProxyType({}),
     image_models_kwargs: Mapping[str, Any] = MappingProxyType({}),
     anndata_kwargs: Mapping[str, Any] = MappingProxyType({}),
@@ -71,14 +71,14 @@ def visium_hd(
     bins_as_squares
         If `True`, the bins are represented as squares. If `False`, the bins are represented as circles. For a correct
         visualization one should use squares.
+    annotate_table_by_labels
+        If `True` will annotate the table with corresponding labels layer representing the bins, if `False`, table will be annotated by a shapes layer.
     fullres_image_file
         Path to the full-resolution image. By default the image is searched in the ``{vx.MICROSCOPE_IMAGE!r}``
         directory.
     load_all_images
         If `False`, load only the full resolution, high resolution and low resolution images. If `True`, also the
         following images: ``{vx.IMAGE_CYTASSIST!r}``.
-    annotate_table_by_labels
-        If `True` will annotate the table with corresponding labels layer representing the bins, if `False`, table will be annotated by a shapes layer.
     imread_kwargs
         Keyword arguments for :func:`imageio.imread`.
     image_models_kwargs


### PR DESCRIPTION
This adds support for annotating the resulting tables with corresponding labels layers (the bins). 

Annotating the table by a labels layer has the advantage that the bins, and their expression levels can be viewed in napari-spatialdata, which is not possible if you annotate via the shapes layers ( it is possible when setting `bins_as_squares` to `False`, but this will give you circles, not squares, which is not ideal ). 

Viewing and loading expression levels for 016um and 008um bins is quite fast, viewing the 002um bins is also still possible, althoug loading expression levels associated with the bins takes some seconds for each gene, but once loaded is quite fast and convenient to view.

See screenshot for 008um:
<img width="1426" alt="Screenshot 2024-09-26 at 14 15 14" src="https://github.com/user-attachments/assets/081b8f30-0184-4ae6-8897-b0161133f180">

It is not as snappy as https://github.com/scverse/spatialdata/blob/8879aff17b8169c6bb6ff3537e4ddcee0204f168/src/spatialdata/_core/operations/rasterize_bins.py#L28, but maybe a little bit more convenient in use.

If this PR would be merged, then this function `spatialdata.rasterize_bins` would also need to be updated. I would remove the `bins` parameter, and estimate the transformation only using the tables, i.e. using `table.obsm[ 'spatial' ]` and the `col_key` and `row_key` in `table.obs`; or get the transformation from the labels layer.
