### PR TITLE
add macsima reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.1.4] - xxxx-xx-xx
 
+## [0.1.4] - 2024-08-07
+
 ### Changed
 
 -   (Xenium) changed default target of table to labels; radii of circles computed from cells, not nuclei #179

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning][].
 
 -   (Xenium) changed default target of table to labels; radii of circles computed from cells, not nuclei #179
 -   (Visium HD) changed default geometry to squares from circles for the bins; added parameter to choose #183
+-   (CosMx) dropping points element with zero-length from the cosmx reader #191
 
 ## [0.1.3] - 2024-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning][].
 ## incoming release
 
 -   (Visium/Visium HD) lowres and hires images now mapped also to the 'global' coordinate system #230
+-   (Macsima) added support @berombau #224
 
 ## [0.1.6] - 2024-11-26
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Note: all mentioned technologies are registered trademarks of their respective c
 
 ## Known limitations
 
-Contributions for addressing the below limitations are very welcomed. 
+Contributions for addressing the below limitations are very welcomed.
 
-- Only Stereo-seq 7.x is supported, 8.x is not currently supported. https://github.com/scverse/spatialdata-io/issues/161
+-   Only Stereo-seq 7.x is supported, 8.x is not currently supported. https://github.com/scverse/spatialdata-io/issues/161
 
 ### How to Contribute
 
@@ -40,7 +40,6 @@ Contributions for addressing the below limitations are very welcomed.
 2. **Submit a Pull Request (PR)**: Once the issue is discussed, submit a PR to the `spatialdata-io` repository. Ensure your PR includes information about a suitable dataset for testing the reader, ideally no larger than 10 GB. Include clear instructions for accessing the data, preferably with a `curl` or `wget` command for easy downloading.
 
 3. **Optional Enhancements**: To facilitate reproducibility and ease of data access, consider adding a folder in the [spatialdata-sandbox](https://github.com/giovp/spatialdata-sandbox) repository. Include a `download.py` and `to_zarr.py` script (refer to examples in the repository) to enable others to reproduce your reader by simply running these scripts sequentially.
-
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This package contains reader functions to load common spatial omics formats into
 -   Steinbock (output data)
 -   STOmics Stereo-seq®
 -   Vizgen MERSCOPE® (MERFISH)
+-   MACSima® (MACS® iQ View output)
 
 Note: all mentioned technologies are registered trademarks of their respective companies.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pyarrow",
     "readfcs",
     "tifffile>=2023.8.12",
+    "ome-types",
 ]
 
 [project.optional-dependencies]

--- a/src/spatialdata_io/__init__.py
+++ b/src/spatialdata_io/__init__.py
@@ -4,6 +4,7 @@ from spatialdata_io.readers.codex import codex
 from spatialdata_io.readers.cosmx import cosmx
 from spatialdata_io.readers.curio import curio
 from spatialdata_io.readers.dbit import dbit
+from spatialdata_io.readers.macsima import macsima
 from spatialdata_io.readers.mcmicro import mcmicro
 from spatialdata_io.readers.merscope import merscope
 from spatialdata_io.readers.seqfish import seqfish
@@ -32,6 +33,7 @@ __all__ = [
     "xenium_explorer_selection",
     "dbit",
     "visium_hd",
+    "macsima",
 ]
 
 __version__ = version("spatialdata-io")

--- a/src/spatialdata_io/readers/_utils/_utils.py
+++ b/src/spatialdata_io/readers/_utils/_utils.py
@@ -89,11 +89,10 @@ def _initialize_raster_models_kwargs(
     return image_models_kwargs, labels_models_kwargs
 
 
-def calc_scale_factors(stack: Any, min_size: int = 1000, default_scale_factor: int = 2) -> list[int]:
+def calc_scale_factors(lower_scale_limit: float, min_size: int = 1000, default_scale_factor: int = 2) -> list[int]:
     """Calculate scale factors based on image size to get lowest resolution under min_size pixels."""
     # get lowest dimension, ignoring channels
-    lower_scale_limit = min(stack.shape[1:])
-    scale_factor = default_scale_factor
+    scale_factor: int = default_scale_factor
     scale_factors = [scale_factor]
     lower_scale_limit /= scale_factor
     while lower_scale_limit >= min_size:

--- a/src/spatialdata_io/readers/_utils/_utils.py
+++ b/src/spatialdata_io/readers/_utils/_utils.py
@@ -8,6 +8,9 @@ from typing import Any, Optional, Union
 import numpy as np
 from anndata import AnnData, read_text
 from h5py import File
+from ome_types import from_tiff
+from ome_types.model import Pixels, UnitsLength
+from spatialdata._logging import logger
 
 from spatialdata_io.readers._utils._read_10x_h5 import _read_10x_h5
 
@@ -18,8 +21,8 @@ try:
 
     NDArrayA = NDArray[Any]
 except (ImportError, TypeError):
-    NDArray = np.ndarray  # type: ignore[misc]
-    NDArrayA = np.ndarray  # type: ignore[misc]
+    NDArray = np.ndarray  # type: ignore[unused-ignore]
+    NDArrayA = np.ndarray  # type: ignore[unused-ignore]
 
 
 def _read_counts(
@@ -84,3 +87,49 @@ def _initialize_raster_models_kwargs(
     if "scale_factors" not in labels_models_kwargs:
         labels_models_kwargs["scale_factors"] = [2, 2, 2, 2]
     return image_models_kwargs, labels_models_kwargs
+
+
+def calc_scale_factors(stack: Any, min_size: int = 1000, default_scale_factor: int = 2) -> list[int]:
+    """Calculate scale factors based on image size to get lowest resolution under min_size pixels."""
+    # get lowest dimension, ignoring channels
+    lower_scale_limit = min(stack.shape[1:])
+    scale_factor = default_scale_factor
+    scale_factors = [scale_factor]
+    lower_scale_limit /= scale_factor
+    while lower_scale_limit >= min_size:
+        # scale_factors are cumulative, so we don't need to do e.g. scale_factor *= 2
+        scale_factors.append(scale_factor)
+        lower_scale_limit /= scale_factor
+    return scale_factors
+
+
+def parse_channels(path: Path) -> list[str]:
+    """Parse channel names from an OME-TIFF file."""
+    images = from_tiff(path).images
+    if len(images) > 1:
+        logger.warning("Found multiple images in OME-TIFF file. Only the first one will be used.")
+    channels = images[0].pixels.channels
+    logger.debug(channels)
+    names = [c.name for c in channels if c.name is not None]
+    return names
+
+
+def parse_physical_size(path: Path | None = None, ome_pixels: Pixels | None = None) -> float:
+    """Parse physical size from OME-TIFF to micrometer."""
+    pixels = ome_pixels or from_tiff(path).images[0].pixels
+    logger.debug(pixels)
+    if pixels.physical_size_x_unit != pixels.physical_size_y_unit:
+        logger.error("Physical units for x and y dimensions are not the same.")
+        raise NotImplementedError
+    if pixels.physical_size_x != pixels.physical_size_y:
+        logger.error("Physical sizes for x and y dimensions are the same.")
+        raise NotImplementedError
+    # convert to micrometer if needed
+    if pixels.physical_size_x_unit == UnitsLength.NANOMETER:
+        physical_size = pixels.physical_size_x / 1000
+    elif pixels.physical_size_x_unit == UnitsLength.MICROMETER:
+        physical_size = pixels.physical_size_x
+    else:
+        logger.error(f"Physical unit not recognized: '{pixels.physical_size_x_unit}'.")
+        raise NotImplementedError
+    return float(physical_size)

--- a/src/spatialdata_io/readers/macsima.py
+++ b/src/spatialdata_io/readers/macsima.py
@@ -193,7 +193,7 @@ def macsima(
 
     .. seealso::
 
-        - `MACSima output <https://application.qitissue.com/getting-started/naming-your-datasets>`_.
+        - `MACSima output <https://application.qimagingsys.com/getting-started/naming-your-datasets>`_.
 
     Parameters
     ----------
@@ -227,7 +227,8 @@ def macsima(
         Threshold for splitting nuclei channels. If the number of channels that include nuclei_channel_name is
         greater than this threshold, the nuclei channels are split into a separate stack.
     skip_rounds
-        List of round numbers to skip when parsing the data. Rounds or cycles are counted from 0 e.g. skip_rounds=[1, 2] will parse only the first round 0 when there are only 3 cycles.
+        List of round numbers to skip when parsing the data. Rounds or cycles are counted from 0 e.g. skip_rounds=[1, 2]
+         will parse only the first round 0 when there are only 3 cycles.
     include_cycle_in_channel_name
         Whether to include the cycle number in the channel name.
 
@@ -326,6 +327,8 @@ def parse_processed_folder(
     """Parse a single folder containing images from a cyclical imaging platform."""
     # get list of image paths, get channel name from OME data and cycle round number from filename
     # look for OME-TIFF files
+    # TODO: replace this pattern and the p.suffix in [".tif", ".tiff"] with a single function based on a regexp, like
+    # this one re.compile(r".*\.tif{1,2}$", re.IGNORECASE)
     path_files = list(path.glob(file_pattern))
     logger.debug(path_files[0])
 

--- a/src/spatialdata_io/readers/macsima.py
+++ b/src/spatialdata_io/readers/macsima.py
@@ -68,10 +68,16 @@ class MultiChannelImage:
                     warnings.simplefilter("ignore")
                     channel_names = parse_channels(p)
                 if len(channel_names) > 1:
-                    logger.warning(f"Found multiple channels in OME-TIFF file {p}. Only the first one will be used.")
+                    warnings.warn(
+                        f"Found multiple channels in OME-TIFF file {p}. Only the first one will be used.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                 channels.append(channel_names[0])
             except ValueError as e:
-                logger.warning(f"Cannot parse OME metadata from {p}. Error: {e}. Skipping this file.")
+                warnings.warn(
+                    f"Cannot parse OME metadata from {p}. Error: {e}. Skipping this file.", UserWarning, stacklevel=2
+                )
 
         if len(path_files) != len(cycles) or len(path_files) != len(channels):
             raise ValueError("Length of path_files, cycles and channels must be the same.")
@@ -80,29 +86,37 @@ class MultiChannelImage:
             logger.info("Skipping cycles: %d", skip_rounds)
             path_files, cycles, channels = map(
                 list,
-                zip(*[(p, c, ch) for p, c, ch in zip(path_files, cycles, channels) if c not in skip_rounds]),
+                zip(
+                    *[
+                        (p, c, ch)
+                        for p, c, ch in zip(path_files, cycles, channels, strict=True)
+                        if c not in skip_rounds
+                    ],
+                    strict=True,
+                ),
             )
         imgs = [imread(img, **imread_kwargs) for img in path_files]
-        for img, path in zip(imgs, path_files):
+        for img, path in zip(imgs, path_files, strict=True):
             if img.shape[1:] != imgs[0].shape[1:]:
                 raise ValueError(
-                    f"Images are not all the same size. Image {path} has shape {img.shape[1:]} while the first image {path_files[0]} has shape {imgs[0].shape[1:]}"
+                    f"Images are not all the same size. Image {path} has shape {img.shape[1:]} while the first image "
+                    f"{path_files[0]} has shape {imgs[0].shape[1:]}"
                 )
         # sort imgs, cycles and channels based on cycles
         output = cls(
             data=imgs,
-            metadata=[ChannelMetadata(name=ch, cycle=c) for c, ch in zip(cycles, channels)],
+            metadata=[ChannelMetadata(name=ch, cycle=c) for c, ch in zip(cycles, channels, strict=True)],
         )
         return output
 
     @classmethod
     def subset_by_channel(cls, mci: MultiChannelImage, c_name: str) -> MultiChannelImage:
-        """Create new MultiChannelImage with only the channels that contain c_name."""
+        """Create new MultiChannelImage with only the channels that contain the string c_name."""
         indices = [i for i, c in enumerate(mci.metadata) if c_name in c.name]
-        return MultiChannelImage.filter_by_index(mci, indices)
+        return MultiChannelImage.subset_by_index(mci, indices)
 
     @classmethod
-    def filter_by_index(cls, mci: MultiChannelImage, indices: list[int]) -> MultiChannelImage:
+    def subset_by_index(cls, mci: MultiChannelImage, indices: list[int]) -> MultiChannelImage:
         """Filter the image by index."""
         metadata = [c for i, c in enumerate(mci.metadata) if i in indices]
         data = [d for i, d in enumerate(mci.data) if i in indices]
@@ -135,37 +149,27 @@ class MultiChannelImage:
 
     def sort_by_channel(self) -> None:
         """Sort the channels by cycle number."""
+        self.data = [d for _, d in sorted(zip(self.metadata, self.data, strict=True), key=lambda x: x[0].cycle)]
         self.metadata = sorted(self.metadata, key=lambda x: x.cycle)
-        self.data = [d for _, d in sorted(zip(self.metadata, self.data), key=lambda x: x[0].cycle)]
 
     def subset(self, subset: int | None = None) -> MultiChannelImage:
-        """Subset the image."""
+        """Subsets the images to keep only the first `subset` x `subset` pixels."""
         if subset:
             self.data = [d[:, :subset, :subset] for d in self.data]
         return self
 
     def subset_channels(self, c_subset: int) -> MultiChannelImage:
-        """Subset the channels."""
+        """Subsets the channels to keep only the first `c_subset` channels."""
         self.data = self.data[:c_subset]
         self.metadata = self.metadata[:c_subset]
         return self
-
-    def subset_by_idx(self, indices: list[int]) -> MultiChannelImage:
-        """Subset the image by index."""
-        data = [d for i, d in enumerate(self.data) if i in indices]
-        metadata = [c for i, c in enumerate(self.metadata) if i in indices]
-        return MultiChannelImage(
-            data=data,
-            metadata=metadata,
-            include_cycle_in_channel_name=self.include_cycle_in_channel_name,
-        )
 
     def calc_scale_factors(self, default_scale_factor: int = 2) -> list[int]:
         lower_scale_limit = min(self.data[0].shape[1:])
         return calc_scale_factors(lower_scale_limit, default_scale_factor=default_scale_factor)
 
     def get_stack(self) -> da.Array:
-        return da.stack(self.data).squeeze()
+        return da.stack(self.data).squeeze(axis=0)
 
 
 def macsima(
@@ -224,7 +228,8 @@ def macsima(
     nuclei_channel_name
         Common string of the nuclei channel to separate nuclei from other channels.
     split_threshold_nuclei_channel
-        Threshold for splitting nuclei channels. If the number of channels that include nuclei_channel_name is greater than this threshold, the nuclei channels are split into a separate stack.
+        Threshold for splitting nuclei channels. If the number of channels that include nuclei_channel_name is
+        greater than this threshold, the nuclei channels are split into a separate stack.
     skip_rounds
         List of round numbers to skip when parsing the data.
     include_cycle_in_channel_name
@@ -383,10 +388,10 @@ def create_sdata(
         split_nuclei = n_nuclei_channels > split_threshold_nuclei_channel
     if split_nuclei:
         # if channel name is nuclei_channel_name, add to seperate nuclei stack
-        nuclei_mci = mci.subset_by_idx(nuclei_idx)
+        nuclei_mci = MultiChannelImage.subset_by_index(mci, indices=nuclei_idx)
         # keep the first nuclei channel in both the stack and the nuclei stack
         nuclei_idx_without_first_and_last = nuclei_idx[1:-1]
-        mci = MultiChannelImage.filter_by_index(
+        mci = MultiChannelImage.subset_by_index(
             mci,
             [i for i in range(len(mci.metadata)) if i not in nuclei_idx_without_first_and_last],
         )

--- a/src/spatialdata_io/readers/macsima.py
+++ b/src/spatialdata_io/readers/macsima.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import warnings
+from collections.abc import Mapping
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+import anndata as ad
+import dask.array as da
+import pandas as pd
+import spatialdata as sd
+from dask_image.imread import imread
+from spatialdata import SpatialData
+from spatialdata._logging import logger
+
+from spatialdata_io._constants._enum import ModeEnum
+from spatialdata_io.readers._utils._utils import (
+    calc_scale_factors,
+    parse_channels,
+    parse_physical_size,
+)
+
+__all__ = ["macsima"]
+
+
+class MACSimaParsingStyle(ModeEnum):
+    """Different parsing styles for MACSima data."""
+
+    PROCESSED_SINGLE_FOLDER = "processed_single_folder"
+    PROCESSED_MULTIPLE_FOLDERS = "processed_multiple_folders"
+    RAW = "raw"
+    AUTO = "auto"
+
+
+def macsima(
+    path: str | Path,
+    parsing_style: MACSimaParsingStyle | str = MACSimaParsingStyle.AUTO,
+    filter_folder_names: list[str] | None = None,
+    imread_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    subset: int | None = None,
+    c_subset: int | None = None,
+    max_chunk_size: int = 1024,
+    c_chunks_size: int = 1,
+    multiscale: bool = True,
+    transformations: bool = True,
+    scale_factors: list[int] | None = None,
+    default_scale_factor: int = 2,
+    nuclei_channel_name: str = "DAPI",
+    skip_rounds: list[int] | None = None,
+) -> SpatialData:
+    """
+    Read *MACSima* formatted dataset.
+
+    This function reads images from a MACSima cyclic imaging experiment. Metadata of the cycle rounds is parsed from the image names. The channel names are parsed from the OME metadata.
+
+    .. seealso::
+
+        - `MACSima output <https://application.qitissue.com/getting-started/naming-your-datasets>`_.
+
+    Parameters
+    ----------
+    path
+        Path to the directory containing the data.
+    parsing_style
+        Parsing style to use. If ``auto``, the parsing style is determined based on the contents of the path.
+    filter_folder_names
+        List of folder names to filter out when parsing multiple folders.
+    imread_kwargs
+        Keyword arguments passed to :func:`dask_image.imread.imread`.
+    subset
+        Subset the image to the first ``subset`` pixels in x and y dimensions.
+    c_subset
+        Subset the image to the first ``c_subset`` channels.
+    max_chunk_size
+        Maximum chunk size for x and y dimensions.
+    c_chunks_size
+        Chunk size for c dimension.
+    multiscale
+        Whether to create a multiscale image.
+    transformations
+        Whether to add a transformation from pixels to microns to the image.
+    scale_factors
+        Scale factors to use for downsampling. If None, scale factors are calculated based on image size.
+    default_scale_factor
+        Default scale factor to use for downsampling.
+    nuclei_channel_name
+        Common string of the nuclei channel to separate nuclei from other channels.
+    skip_rounds
+        List of round numbers to skip when parsing the data.
+
+    Returns
+    -------
+    :class:`spatialdata.SpatialData`
+    """
+    path = Path(path)
+    if not isinstance(parsing_style, MACSimaParsingStyle):
+        parsing_style = MACSimaParsingStyle(parsing_style)
+
+    if parsing_style == MACSimaParsingStyle.AUTO:
+        assert path.is_dir(), f"Path {path} is not a directory."
+
+        if any(p.suffix in [".tif", ".tiff"] for p in path.iterdir()):
+            # if path contains tifs, do parse_processed_folder on path
+            parsing_style = MACSimaParsingStyle.PROCESSED_SINGLE_FOLDER
+        elif all(p.is_dir() for p in path.iterdir() if not p.name.startswith(".")):
+            # if path contains only folders or hidden files, do parse_processed_folder on each folder
+            parsing_style = MACSimaParsingStyle.PROCESSED_MULTIPLE_FOLDERS
+        else:
+            raise ValueError(f"Cannot determine parsing style for path {path}. Please specify the parsing style.")
+
+    if parsing_style == MACSimaParsingStyle.PROCESSED_SINGLE_FOLDER:
+        return parse_processed_folder(
+            path,
+            imread_kwargs,
+            subset,
+            c_subset,
+            max_chunk_size,
+            c_chunks_size,
+            multiscale,
+            transformations,
+            scale_factors,
+            default_scale_factor,
+            nuclei_channel_name,
+            skip_rounds,
+        )
+    if parsing_style == MACSimaParsingStyle.PROCESSED_MULTIPLE_FOLDERS:
+        sdatas = {}
+        # iterate over all non-filtered folders in path and parse each folder
+        for p in [
+            p
+            for p in path.iterdir()
+            if p.is_dir() and (not filter_folder_names or not any(f in p.name for f in filter_folder_names))
+        ]:
+            sdatas[p.stem] = parse_processed_folder(
+                p,
+                imread_kwargs,
+                subset,
+                c_subset,
+                max_chunk_size,
+                c_chunks_size,
+                multiscale,
+                transformations,
+                scale_factors,
+                default_scale_factor,
+                nuclei_channel_name,
+                skip_rounds,
+            )
+        return sd.concatenate(list(sdatas.values()))
+    if parsing_style == MACSimaParsingStyle.RAW:
+        # TODO: see https://github.com/scverse/spatialdata-io/issues/155
+        raise NotImplementedError("Parsing raw MACSima data is not yet implemented.")
+
+
+def parse_name_to_cycle(name: str) -> int:
+    """Parse the cycle number from the name of the image."""
+    cycle = name.split("_")[0]
+    if "-" in cycle:
+        cycle = cycle.split("-")[1]
+    return int(cycle)
+
+
+def parse_processed_folder(
+    path: Path,
+    imread_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    subset: int | None = None,
+    c_subset: int | None = None,
+    max_chunk_size: int = 1024,
+    c_chunks_size: int = 1,
+    multiscale: bool = True,
+    transformations: bool = True,
+    scale_factors: list[int] | None = None,
+    default_scale_factor: int = 2,
+    nuclei_channel_name: str = "DAPI",
+    skip_rounds: list[int] | None = None,
+    file_pattern: str = "*.tif*",
+) -> SpatialData:
+    """Parse a single folder containing images from a cyclical imaging platform."""
+    # get list of image paths, get channel name from OME data and cycle round number from filename
+    # look for OME-TIFF files
+    path_files = list(path.glob(file_pattern))
+    logger.debug(path_files[0])
+    # make sure not to remove round 0 when parsing!
+    cycles = []
+    channels = []
+    for p in path_files:
+        cycle = parse_name_to_cycle(p.stem)
+        cycles.append(cycle)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                channel_names = parse_channels(p)
+            if len(channel_names) > 1:
+                logger.warning(f"Found multiple channels in OME-TIFF file {p}. Only the first one will be used.")
+            channels.append(channel_names[0])
+        except ValueError as e:
+            logger.warning(f"Cannot parse OME metadata from {p}. Error: {e}. Skipping this file.")
+    stack, sorted_cycles, sorted_channels = get_stack(
+        path_files,
+        cycles,
+        channels,
+        imread_kwargs,
+        skip_rounds=skip_rounds,
+    )
+
+    sorted_cycle_channels: list[str] = []
+    for c, ch in zip(sorted_cycles, sorted_channels):
+        sorted_cycle_channels.append(f"R{str(c)} {ch}")
+
+    # do subsetting if needed
+    if subset:
+        stack = stack[:, :subset, :subset]
+    if c_subset:
+        stack = stack[:c_subset, :, :]
+        sorted_cycle_channels = sorted_cycle_channels[:c_subset]
+    if multiscale and not scale_factors:
+        scale_factors = calc_scale_factors(stack, default_scale_factor=default_scale_factor)
+    if not multiscale:
+        scale_factors = None
+    logger.debug(f"Scale factors: {scale_factors}")
+
+    filtered_name = path.stem.replace(" ", "_")
+
+    return create_sdata(
+        stack,
+        sorted_cycle_channels,
+        path_files,
+        max_chunk_size,
+        c_chunks_size,
+        transformations,
+        scale_factors,
+        nuclei_channel_name,
+        filtered_name,
+    )
+
+
+def create_sdata(
+    stack: da.Array,
+    sorted_cycle_channels: list[str],
+    path_files: list[Path],
+    max_chunk_size: int,
+    c_chunks_size: int,
+    transformations: bool,
+    scale_factors: list[int] | None,
+    nuclei_channel_name: str,
+    filtered_name: str,
+) -> SpatialData:
+    # for stack and sorted_cycle_channels, if channel name is nuclei_channel_name, add to seperate nuclei stack
+    # keep the first nuclei channel in both the stack and the nuclei stack
+    nuclei_sorted_cycle_channels = []
+    nuclei_idx = []
+    for i, c in enumerate(sorted_cycle_channels):
+        if nuclei_channel_name in c:
+            nuclei_sorted_cycle_channels.append(c)
+            nuclei_idx.append(i)
+    if len(nuclei_idx) > 2:
+        has_nuclei_stack = True
+        # More than two nuclei channels found, keep only the first and last one in the stack
+        nuclei_stack = stack[nuclei_idx]
+        nuclei_idx_without_first_and_last = nuclei_idx[1:-1]
+        stack = stack[[i for i in range(len(sorted_cycle_channels)) if i not in nuclei_idx_without_first_and_last]]
+        sorted_cycle_channels = [
+            c for i, c in enumerate(sorted_cycle_channels) if i not in nuclei_idx_without_first_and_last
+        ]
+    else:
+        has_nuclei_stack = False
+    # Only one or two nuclei channels found, keep all in the stack
+    pixels_to_microns = parse_physical_size(path_files[0])
+    image_element = create_image_element(
+        stack,
+        sorted_cycle_channels,
+        max_chunk_size,
+        c_chunks_size,
+        transformations,
+        pixels_to_microns,
+        scale_factors,
+        name=filtered_name,
+    )
+    if has_nuclei_stack:
+        nuclei_image_element = create_image_element(
+            nuclei_stack,
+            nuclei_sorted_cycle_channels,
+            max_chunk_size,
+            c_chunks_size,
+            transformations,
+            pixels_to_microns,
+            scale_factors,
+            name=filtered_name,
+        )
+        table_nuclei = create_table(nuclei_sorted_cycle_channels)
+    table_channels = create_table(sorted_cycle_channels)
+
+    sdata = sd.SpatialData(
+        images={
+            f"{filtered_name}_image": image_element,
+        },
+        tables={
+            f"{filtered_name}_table": table_channels,
+        },
+    )
+    if has_nuclei_stack:
+        sdata.images[f"{filtered_name}_nuclei_image"] = nuclei_image_element
+        sdata.tables[f"{filtered_name}_nuclei_table"] = table_nuclei
+
+    return sdata
+
+
+def create_table(sorted_cycle_channels: list[str]) -> ad.AnnData:
+    df = pd.DataFrame(
+        {
+            "name": sorted_cycle_channels,
+            "cycle": [int(c.split(" ")[0][1:]) for c in sorted_cycle_channels],
+        }
+    )
+    table = ad.AnnData(var=df)
+    table.var_names = sorted_cycle_channels
+    return sd.models.TableModel.parse(table)
+
+
+def create_image_element(
+    stack: da.Array,
+    sorted_channels: list[str],
+    max_chunk_size: int,
+    c_chunks_size: int,
+    transformations: bool,
+    pixels_to_microns: float,
+    scale_factors: list[int] | None,
+    name: str | None = None,
+) -> sd.models.Image2DModel:
+    t_dict = None
+    if transformations:
+        t_pixels_to_microns = sd.transformations.Scale([pixels_to_microns, pixels_to_microns], axes=("x", "y"))
+        # 'microns' is also used in merscope example
+        # no inverse needed as the transformation is already from pixels to microns
+        t_dict = {name: t_pixels_to_microns}
+    # # chunk_size can be 1 for channels
+    chunks = {
+        "x": max_chunk_size,
+        "y": max_chunk_size,
+        "c": c_chunks_size,
+    }
+    if t_dict:
+        logger.debug("Adding transformation: %s", t_dict)
+    el = sd.models.Image2DModel.parse(
+        stack,
+        # TODO: make sure y and x locations are correct
+        dims=["c", "y", "x"],
+        scale_factors=scale_factors,
+        chunks=chunks,
+        c_coords=sorted_channels,
+        transformations=t_dict,
+    )
+    return el
+
+
+def get_stack(
+    path_files: list[Path],
+    cycles: list[int],
+    channels: list[str],
+    imread_kwargs: Mapping[str, Any],
+    skip_rounds: list[int] | None = None,
+) -> tuple[da.Array, list[int], list[str]]:
+    if len(path_files) != len(cycles) or len(path_files) != len(channels):
+        raise ValueError("Length of path_files, cycles and channels must be the same.")
+    # if any of round_channels is in skip_rounds, remove that round from the list and from path_files
+    if skip_rounds:
+        logger.info("Skipping cycles: %d", skip_rounds)
+        path_files, cycles, channels = map(
+            list,
+            zip(*[(p, c, ch) for p, c, ch in zip(path_files, cycles, channels) if c not in skip_rounds]),
+        )
+    imgs = [imread(img, **imread_kwargs) for img in path_files]
+    for img, path in zip(imgs, path_files):
+        if img.shape[1:] != imgs[0].shape[1:]:
+            raise ValueError(
+                f"Images are not all the same size. Image {path} has shape {img.shape[1:]} while the first image {path_files[0]} has shape {imgs[0].shape[1:]}"
+            )
+    # sort imgs, cycles and channels based on cycles
+    imgs, cycles, channels = map(
+        list,
+        zip(*sorted(zip(imgs, cycles, channels), key=lambda x: (x[1]))),
+    )
+    stack = da.stack(imgs).squeeze()
+    return stack, cycles, channels

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,0 +1,31 @@
+import sys
+
+import pytest
+
+
+def skip_if_below_python_version() -> pytest.mark.skipif:
+    """
+    Decorator to skip tests if the Python version is below a specified version.
+
+    This decorator prevents running tests on unsupported Python versions. Update the `MIN_VERSION`
+    constant to change the minimum Python version required for the tests.
+
+    Returns
+    -------
+    pytest.mark.skipif
+        A pytest marker that skips the test if the current Python version is below the specified `MIN_VERSION`.
+
+    Notes
+    -----
+    The current minimum version is set to Python 3.10. Adjust the `MIN_VERSION` constant as needed
+    to accommodate newer Python versions.
+
+    Examples
+    --------
+    >>> @skip_if_below_python_version()
+    >>> def test_some_feature():
+    >>>     assert True
+    """
+    MIN_VERSION = (3, 10)
+    reason = f"Test requires Python {'.'.join(map(str, MIN_VERSION))} or higher"
+    return pytest.mark.skipif(sys.version_info < MIN_VERSION, reason=reason)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -26,6 +26,6 @@ def skip_if_below_python_version() -> pytest.mark.skipif:
     >>> def test_some_feature():
     >>>     assert True
     """
-    MIN_VERSION = (3, 10)
+    MIN_VERSION = (3, 12)
     reason = f"Test requires Python {'.'.join(map(str, MIN_VERSION))} or higher"
     return pytest.mark.skipif(sys.version_info < MIN_VERSION, reason=reason)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -26,6 +26,6 @@ def skip_if_below_python_version() -> pytest.mark.skipif:
     >>> def test_some_feature():
     >>>     assert True
     """
-    MIN_VERSION = (3, 12)
+    MIN_VERSION = (3, 10)
     reason = f"Test requires Python {'.'.join(map(str, MIN_VERSION))} or higher"
     return pytest.mark.skipif(sys.version_info < MIN_VERSION, reason=reason)

--- a/tests/test_macsima.py
+++ b/tests/test_macsima.py
@@ -1,0 +1,111 @@
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from spatialdata.models import get_channels
+
+from spatialdata_io.readers.macsima import macsima
+
+if not (Path("./data/Lung_adc_demo").exists() or Path("./data/MACSimaData_HCA").exists()):
+    # The datasets should be downloaded and placed unzipped in the "data" directory;
+    # MACSimaData_HCA/ with e.g. unzipped HumanLiverH35/ inside: https://livercellatlas.org/download.php
+    # Lung_adc_demo/: Ask Miltenyi Biotec for the demo dataset
+    pytest.skip(
+        "requires the Lung_adc_demo or MACSimaData_HCA datasets",
+        allow_module_level=True,
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@pytest.mark.parametrize(
+    "dataset,expected",
+    [
+        ("Lung_adc_demo", {"y": (0, 15460), "x": (0, 13864)}),
+        ("MACSimaData_HCA/HumanLiverH35", {"y": (0, 1154), "x": (0, 1396)}),
+    ],
+)
+def test_image_size(dataset: str, expected: dict[str, Any]) -> None:
+    from spatialdata import get_extent
+
+    f = Path("./data") / dataset
+    assert f.is_dir()
+    sdata = macsima(f)
+    el = sdata[list(sdata.images.keys())[0]]
+    cs = sdata.coordinate_systems[0]
+
+    extent: dict[str, tuple[float, float]] = get_extent(el, coordinate_system=cs)
+    extent = {ax: (math.floor(extent[ax][0]), math.ceil(extent[ax][1])) for ax in extent}
+    assert extent == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@pytest.mark.parametrize(
+    "dataset,expected",
+    [("Lung_adc_demo", 116), ("MACSimaData_HCA/HumanLiverH35", 102)],
+)
+def test_total_channels(dataset: str, expected: int) -> None:
+    f = Path("./data") / dataset
+    assert f.is_dir()
+    sdata = macsima(f)
+    el = sdata[list(sdata.images.keys())[0]]
+
+    # get the number of channels
+    channels: int = len(get_channels(el))
+    assert channels == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@pytest.mark.parametrize(
+    "dataset,expected",
+    [
+        ("Lung_adc_demo", ["R0 DAPI", "R1 CD68", "R1 CD163"]),
+        ("MACSimaData_HCA/HumanLiverH35", ["R0 DAPI", "R1 PE", "R1 DAPI"]),
+    ],
+)
+def test_channel_names(dataset: str, expected: list[str]) -> None:
+    f = Path("./data") / dataset
+    assert f.is_dir()
+    sdata = macsima(f, c_subset=3)
+    el = sdata[list(sdata.images.keys())[0]]
+
+    # get the channel names
+    channels = get_channels(el)
+    assert list(channels) == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@pytest.mark.parametrize(
+    "dataset,expected",
+    [
+        ("Lung_adc_demo", [0, 1, 1]),
+        ("MACSimaData_HCA/HumanLiverH35", [0, 1, 1]),
+    ],
+)
+def test_cycle_metadata(dataset: str, expected: list[str]) -> None:
+    f = Path("./data") / dataset
+    assert f.is_dir()
+    sdata = macsima(f, c_subset=3)
+    table = sdata[list(sdata.tables.keys())[0]]
+
+    # get the channel names
+    cycles = table.var["cycle"]
+    assert list(cycles) == expected
+
+
+def test_parsing_style() -> None:
+    with pytest.raises(ValueError):
+        macsima(Path("."), parsing_style="not_a_parsing_style")
+
+
+# @pytest.mark.parametrize(
+#     "name,expected",
+#     [
+#         ("C-002_S-000_S_FITC_R-01_W-C-1_ROI-01_A-CD147_C-REA282.tif", 2),
+#         ("001_S_R-01_W-B-1_ROI-01_A-CD14REA599ROI1_C-REA599.ome.tif", 1),
+#     ],
+# )
+# def test_parsing_of_name_to_cycle(name: str, expected: int) -> None:
+#     result = parse_name_to_cycle(name)
+#     assert result == expected

--- a/tests/test_macsima.py
+++ b/tests/test_macsima.py
@@ -1,24 +1,22 @@
 import math
-import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
-from spatialdata.models import get_channels
+from spatialdata.models import get_channel_names
 
 from spatialdata_io.readers.macsima import macsima, parse_name_to_cycle
+from tests._utils import skip_if_below_python_version
 
 if not (Path("./data/Lung_adc_demo").exists() or Path("./data/MACSimaData_HCA").exists()):
-    # The datasets should be downloaded and placed unzipped in the "data" directory;
-    # MACSimaData_HCA/ with e.g. unzipped HumanLiverH35/ inside: https://livercellatlas.org/download.php
-    # Lung_adc_demo/: Ask Miltenyi Biotec for the demo dataset
     pytest.skip(
-        "requires the Lung_adc_demo or MACSimaData_HCA datasets",
+        "Requires the Lung_adc_demo or MACSimaData_HCA datasets, please check "
+        "https://github.com/giovp/spatialdata-sandbox/macsima/Readme.md for instructions on how to get the data.",
         allow_module_level=True,
     )
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@skip_if_below_python_version()
 @pytest.mark.parametrize(
     "dataset,expected",
     [
@@ -40,7 +38,7 @@ def test_image_size(dataset: str, expected: dict[str, Any]) -> None:
     assert extent == expected
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@skip_if_below_python_version()
 @pytest.mark.parametrize(
     "dataset,expected",
     [("Lung_adc_demo", 116), ("MACSimaData_HCA/HumanLiverH35", 102)],
@@ -52,11 +50,11 @@ def test_total_channels(dataset: str, expected: int) -> None:
     el = sdata[list(sdata.images.keys())[0]]
 
     # get the number of channels
-    channels: int = len(get_channels(el))
+    channels: int = len(get_channel_names(el))
     assert channels == expected
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@skip_if_below_python_version()
 @pytest.mark.parametrize(
     "dataset,expected",
     [
@@ -71,11 +69,11 @@ def test_channel_names(dataset: str, expected: list[str]) -> None:
     el = sdata[list(sdata.images.keys())[0]]
 
     # get the channel names
-    channels = get_channels(el)
+    channels = get_channel_names(el)
     assert list(channels) == expected
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@skip_if_below_python_version()
 @pytest.mark.parametrize(
     "dataset,expected",
     [

--- a/tests/test_macsima.py
+++ b/tests/test_macsima.py
@@ -14,6 +14,8 @@ from spatialdata_io.readers.macsima import (
 )
 from tests._utils import skip_if_below_python_version
 
+RNG = da.random.default_rng(seed=0)
+
 if not (Path("./data/Lung_adc_demo").exists() or Path("./data/MACSimaData_HCA").exists()):
     pytest.skip(
         "Requires the Lung_adc_demo or MACSimaData_HCA datasets, please check "
@@ -116,12 +118,11 @@ def test_parsing_of_name_to_cycle(name: str, expected: int) -> None:
 
 
 def test_mci_sort_by_channel() -> None:
-    rng = da.random.default_rng()
     sizes = [100, 200, 300]
     c_names = ["test11", "test3", "test2"]
     cycles = [2, 0, 1]
     mci = MultiChannelImage(
-        data=[rng.random((size, size), chunks=(10, 10)) for size in sizes],
+        data=[RNG.random((size, size), chunks=(10, 10)) for size in sizes],
         metadata=[ChannelMetadata(name=c_name, cycle=cycle) for c_name, cycle in zip(c_names, cycles)],
     )
     assert mci.get_channel_names() == c_names

--- a/tests/test_macsima.py
+++ b/tests/test_macsima.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from spatialdata.models import get_channels
 
-from spatialdata_io.readers.macsima import macsima
+from spatialdata_io.readers.macsima import macsima, parse_name_to_cycle
 
 if not (Path("./data/Lung_adc_demo").exists() or Path("./data/MACSimaData_HCA").exists()):
     # The datasets should be downloaded and placed unzipped in the "data" directory;
@@ -67,7 +67,7 @@ def test_total_channels(dataset: str, expected: int) -> None:
 def test_channel_names(dataset: str, expected: list[str]) -> None:
     f = Path("./data") / dataset
     assert f.is_dir()
-    sdata = macsima(f, c_subset=3)
+    sdata = macsima(f, c_subset=3, include_cycle_in_channel_name=True)
     el = sdata[list(sdata.images.keys())[0]]
 
     # get the channel names
@@ -99,13 +99,13 @@ def test_parsing_style() -> None:
         macsima(Path("."), parsing_style="not_a_parsing_style")
 
 
-# @pytest.mark.parametrize(
-#     "name,expected",
-#     [
-#         ("C-002_S-000_S_FITC_R-01_W-C-1_ROI-01_A-CD147_C-REA282.tif", 2),
-#         ("001_S_R-01_W-B-1_ROI-01_A-CD14REA599ROI1_C-REA599.ome.tif", 1),
-#     ],
-# )
-# def test_parsing_of_name_to_cycle(name: str, expected: int) -> None:
-#     result = parse_name_to_cycle(name)
-#     assert result == expected
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("C-002_S-000_S_FITC_R-01_W-C-1_ROI-01_A-CD147_C-REA282.tif", 2),
+        ("001_S_R-01_W-B-1_ROI-01_A-CD14REA599ROI1_C-REA599.ome.tif", 1),
+    ],
+)
+def test_parsing_of_name_to_cycle(name: str, expected: int) -> None:
+    result = parse_name_to_cycle(name)
+    assert result == expected

--- a/tests/test_macsima.py
+++ b/tests/test_macsima.py
@@ -98,7 +98,7 @@ def test_total_rounds(dataset: str, expected: list[int]) -> None:
     assert max_cycle == expected
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@skip_if_below_python_version()
 @pytest.mark.parametrize(
     "dataset,skip_rounds,expected",
     [
@@ -117,11 +117,11 @@ def test_skip_rounds(dataset: str, skip_rounds: list[int], expected: list[str]) 
     el = sdata[list(sdata.images.keys())[0]]
 
     # get the channel names
-    channels = get_channels(el)
+    channels = get_channel_names(el)
     assert list(channels) == expected, f"Expected {expected}, got {list(channels)}"
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test requires Python 3.10 or higher")
+@skip_if_below_python_version()
 @pytest.mark.parametrize(
     "dataset,expected",
     [

--- a/tests/test_xenium.py
+++ b/tests/test_xenium.py
@@ -1,5 +1,4 @@
 import math
-import sys
 from pathlib import Path
 
 import numpy as np
@@ -10,6 +9,7 @@ from spatialdata_io.readers.xenium import (
     prefix_suffix_uint32_from_cell_id_str,
     xenium,
 )
+from tests._utils import skip_if_below_python_version
 
 
 def test_cell_id_str_from_prefix_suffix_uint32() -> None:
@@ -46,7 +46,7 @@ def test_roundtrip_with_data_limits() -> None:
 # pointing to "data".
 # The GitHub workflow "prepare_test_data.yaml" takes care of downloading the datasets and uploading an artifact for the
 # tests to use
-@pytest.mark.skipif(sys.version_info < (3, 12), reason="Test requires Python 3.10 or higher")
+@skip_if_below_python_version()
 @pytest.mark.parametrize(
     "dataset,expected",
     [


### PR DESCRIPTION
Redo of previous work in https://github.com/scverse/spatialdata-io/pull/156.

This tries to solve #155.

Lung_adc_demo
```python
from spatialdata_io import macsima
sdata = macsima('./Lung_adc_demo', subset=1000)
sdata
```

Note that now the cycle information is added to a table and that the coordinate systems are named after the dataset.
```
SpatialData object
├── Images
│     └── 'Lung_adc_demo_image': DataTree[cyx] (116, 1000, 1000), (116, 500, 500)
└── Tables
      └── 'Lung_adc_demo_table': AnnData (0, 116)
with coordinate systems:
    ▸ 'Lung_adc_demo', with elements:
        Lung_adc_demo_image (Images)
```

For the LiverCellAtlas data, it stores all middle cycle nuclei channels in a different image and table.
```
SpatialData object
├── Images
│     ├── 'HumanLiverH36_image': DataTree[cyx] (102, 5772, 6621), (102, 2886, 3310), (102, 1443, 1655), (102, 721, 827)
│     └── 'HumanLiverH36_nuclei_image': DataTree[cyx] (50, 5772, 6621), (50, 2886, 3310), (50, 1443, 1655), (50, 721, 827)
└── Tables
      ├── 'HumanLiverH36_nuclei_table': AnnData (0, 50)
      └── 'HumanLiverH36_table': AnnData (0, 102)
with coordinate systems:
    ▸ 'HumanLiverH36', with elements:
        HumanLiverH36_image (Images), HumanLiverH36_nuclei_image (Images)
```


Parsing of raw data should be another PR. It differs in the handling of metadata for channels and cycles from https://gustaveroussy.github.io/sopa/api/io/#sopa.io.macsima @quentinblampey.

The channel naming is different (`R{cycle} {marker}` instead of `{marker}{ (duplicate_number if duplicate markers)`). I like both styles, so I'll try to add later style as well and add a parameter.