### PR TITLE
Reduce reader memory consumption

### DIFF
--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -451,6 +451,8 @@ def xenium(
                 )
                 del sdata.images[key]
 
+    sdata.write_consolidated_metadata()
+
     return sdata
 
 


### PR DESCRIPTION
It adds a new `output_path` parameter in a reader's function that allows to save every element of the spatialdata object as soon as it's created.
This frees up part of the memory during the function's execution instead of maintaining the whole spatialdata object in memory and then saving it with `sdata.write`.

I've done it only for Xenium but if I receive the ok I can implement it for the rest of the readers.