### PR TITLE
Detect VisiumHD full-res image when path is relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## incoming release
+
+-   (Visium/Visium HD) lowres and hires images now mapped also to the 'global' coordinate system #230
+
 ## [0.1.6] - 2024-11-26
 
 -   (MERSCOPE) added `feature_key` attribute for points (i.e., the `'gene'` column) #210

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -231,14 +231,14 @@ def visium(
         image_hires = imread(path / VisiumKeys.IMAGE_HIRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)
         image_hires = DataArray(image_hires, dims=("c", "y", "x"))
         images[dataset_id + "_hires_image"] = Image2DModel.parse(
-            image_hires, transformations={"downscaled_hires": Identity()}, rgb=None
+            image_hires, transformations={"downscaled_hires": Identity(), "global": transform_hires.inverse()}, rgb=None
         )
     if (path / VisiumKeys.IMAGE_LOWRES_FILE).exists():
         image_lowres = imread(path / VisiumKeys.IMAGE_LOWRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)
         image_lowres = DataArray(image_lowres, dims=("c", "y", "x"))
         images[dataset_id + "_lowres_image"] = Image2DModel.parse(
             image_lowres,
-            transformations={"downscaled_lowres": Identity()},
+            transformations={"downscaled_lowres": Identity(), "global": transform_lowres.inverse()},
             rgb=None,
         )
 

--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -306,7 +306,7 @@ def visium_hd(
     )
     set_transformation(
         images[dataset_id + "_hires_image"],
-        {"downscaled_hires": Identity()},
+        {"downscaled_hires": Identity(), "global": transform_hires.inverse()},
         set_all=True,
     )
 
@@ -324,7 +324,7 @@ def visium_hd(
     )
     set_transformation(
         images[dataset_id + "_lowres_image"],
-        {"downscaled_lowres": Identity()},
+        {"downscaled_lowres": Identity(), "global": transform_lowres.inverse()},
         set_all=True,
     )
 

--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import warnings
 from collections.abc import Mapping
@@ -116,12 +115,12 @@ def visium_hd(
             stacklevel=2,
         )
 
-    def _get_bins(path: Path) -> list[str]:
+    def _get_bins(path_bins: Path) -> list[str]:
         return sorted(
             [
-                bin_size
-                for bin_size in os.listdir(path)
-                if os.path.isdir(os.path.join(path, bin_size)) and bin_size.startswith(VisiumHDKeys.BIN_PREFIX)
+                bin_size.name
+                for bin_size in path_bins.iterdir()
+                if bin_size.is_dir() and bin_size.name.startswith(VisiumHDKeys.BIN_PREFIX)
             ]
         )
 
@@ -265,10 +264,7 @@ def visium_hd(
     else:
         path_fullres = path / VisiumHDKeys.MICROSCOPE_IMAGE
         if path_fullres.exists():
-            fullres_image_filenames = [
-                f for f in os.listdir(path_fullres) if os.path.isfile(os.path.join(path_fullres, f))
-            ]
-            fullres_image_paths = [path_fullres / image_filename for image_filename in fullres_image_filenames]
+            fullres_image_paths = [file for file in path_fullres.iterdir() if file.is_file()]
         elif list((path_fullres := (path / f"{filename_prefix}tissue_image")).parent.glob(f"{path_fullres.name}.*")):
             fullres_image_paths = list(path_fullres.parent.glob(f"{path_fullres.name}.*"))
         else:
@@ -291,7 +287,7 @@ def visium_hd(
 
     if fullres_image_file is not None:
         load_image(
-            path=path / fullres_image_file,
+            path=fullres_image_file,
             suffix="_full_image",
             scale_factors=[2, 2, 2, 2],
         )
@@ -356,7 +352,7 @@ def visium_hd(
 
 def _infer_dataset_id(path: Path) -> str:
     suffix = f"_{VisiumHDKeys.FEATURE_SLICE_FILE.value}"
-    files = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) and f.endswith(suffix)]
+    files = [file.name for file in path.iterdir() if file.is_file() and file.name.endswith(suffix)]
     if len(files) == 0 or len(files) > 1:
         raise ValueError(
             f"Cannot infer `dataset_id` from the feature slice file in {path}, please pass `dataset_id` as an argument."


### PR DESCRIPTION
There is a minor bug in the Visium HD reader. When we provide a relative path to the data, e.g. `"data/Visium_HD_Mouse_Small_Intestine"`, then it will search for the microscopy image inside `"data/Visium_HD_Mouse_Small_Intestine/data/Visium_HD_Mouse_Small_Intestine/microscope_image"`.

This is because it was using `path / fullres_image_file` instead of simply `fullres_image_file`.

I also did some minor updates to use `pathlib` everywhere instead of a combination of `pathlib` and `os` (it makes the code more readable I think).