### PR TITLE
resolves spatialdata_io.xenium() capability to read in xeniumranger v3.0.1.1 resegemented data

### DIFF
--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -145,8 +145,9 @@ class XeniumKeys(ModeEnum):
 
     # specs keys
     ANALYSIS_SW_VERSION = "analysis_sw_version"
-    XENIUM_RANGER = "xenium_ranger" #spec which contains xeniumranger version (after resegment is run from xenium-3.0.1.1)
-
+    XENIUM_RANGER = (
+        "xenium_ranger"  # spec which contains xeniumranger version (after resegment is run from xenium-3.0.1.1)
+    )
 
     # zarr file with labels file and cell summary keys
     CELLS_ZARR = "cells.zarr.zip"

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -145,6 +145,8 @@ class XeniumKeys(ModeEnum):
 
     # specs keys
     ANALYSIS_SW_VERSION = "analysis_sw_version"
+    XENIUM_RANGER = "xenium_ranger" #spec which contains xeniumranger version (after resegment is run from xenium-3.0.1.1)
+
 
     # zarr file with labels file and cell summary keys
     CELLS_ZARR = "cells.zarr.zip"

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -145,7 +145,8 @@ class XeniumKeys(ModeEnum):
 
     # specs keys
     ANALYSIS_SW_VERSION = "analysis_sw_version"
-    # spec which contains xeniumranger version (after resegment is run from xenium-3.0.1.1)
+    # spec which contains xeniumranger version whenever xeniumranger is used to resegment the data; the new, resegmented data
+    # needs to be parsed by considering the xeniumranger version
     XENIUM_RANGER = "xenium_ranger"
 
     # zarr file with labels file and cell summary keys

--- a/src/spatialdata_io/_constants/_constants.py
+++ b/src/spatialdata_io/_constants/_constants.py
@@ -145,9 +145,8 @@ class XeniumKeys(ModeEnum):
 
     # specs keys
     ANALYSIS_SW_VERSION = "analysis_sw_version"
-    XENIUM_RANGER = (
-        "xenium_ranger"  # spec which contains xeniumranger version (after resegment is run from xenium-3.0.1.1)
-    )
+    # spec which contains xeniumranger version (after resegment is run from xenium-3.0.1.1)
+    XENIUM_RANGER = "xenium_ranger"
 
     # zarr file with labels file and cell summary keys
     CELLS_ZARR = "cells.zarr.zip"

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -719,7 +719,17 @@ def _parse_version_of_xenium_analyzer(
     specs: dict[str, Any],
     hide_warning: bool = True,
 ) -> packaging.version.Version | None:
-    string = specs[XeniumKeys.ANALYSIS_SW_VERSION]
+    
+    #After using xeniumranger 3.0.1.1 to resegment data from xenium-1.6.0.7, a new dict is added to `specs`, named 'xenium_ranger', 
+    #which contains the key 'version' and it's value pair 'xenium-3.0.1.1' for the resegmented,
+    #which contains a new 'version' key and value is added in specs, using this version (rather than the original 'analysis_sw_version'),
+    #corrects branching and parsing when using xenium() on the xeniumranger resegmented /outs/ folder path
+    if specs.get(XeniumKeys.XENIUM_RANGER):  
+        string = specs[XeniumKeys.XENIUM_RANGER]['version']
+    else:
+        string = specs[XeniumKeys.ANALYSIS_SW_VERSION]
+
+
     pattern = r"^(?:x|X)enium-(\d+\.\d+\.\d+(\.\d+-\d+)?)"
 
     result = re.search(pattern, string)

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -720,10 +720,11 @@ def _parse_version_of_xenium_analyzer(
     hide_warning: bool = True,
 ) -> packaging.version.Version | None:
 
-    # After using xeniumranger 3.0.1.1 to resegment data from xenium-1.6.0.7, a new dict is added to `specs`, named 'xenium_ranger',
-    # which contains the key 'version' and it's value pair 'xenium-3.0.1.1' for the resegmented,
-    # which contains a new 'version' key and value is added in specs, using this version (rather than the original 'analysis_sw_version'),
-    # corrects branching and parsing when using xenium() on the xeniumranger resegmented /outs/ folder path
+    # After using xeniumranger (e.g. 3.0.1.1) to resegment data from previous versions (e.g. xenium-1.6.0.7), a new dict is added to 
+    # `specs`, named 'xenium_ranger', which contains the key 'version' and whose value specifies the version of xeniumrenger used to 
+    # resegment the data (e.g. 'xenium-3.0.1.1').
+    # Using this version (rather than the original 'analysis_sw_version'), corrects branching and parsing when using xenium() on the 
+    # xeniumranger resegmented /outs/ folder path
     if specs.get(XeniumKeys.XENIUM_RANGER):
         string = specs[XeniumKeys.XENIUM_RANGER]["version"]
     else:

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -720,10 +720,10 @@ def _parse_version_of_xenium_analyzer(
     hide_warning: bool = True,
 ) -> packaging.version.Version | None:
 
-    # After using xeniumranger (e.g. 3.0.1.1) to resegment data from previous versions (e.g. xenium-1.6.0.7), a new dict is added to 
-    # `specs`, named 'xenium_ranger', which contains the key 'version' and whose value specifies the version of xeniumrenger used to 
+    # After using xeniumranger (e.g. 3.0.1.1) to resegment data from previous versions (e.g. xenium-1.6.0.7), a new dict is added to
+    # `specs`, named 'xenium_ranger', which contains the key 'version' and whose value specifies the version of xeniumrenger used to
     # resegment the data (e.g. 'xenium-3.0.1.1').
-    # Using this version (rather than the original 'analysis_sw_version'), corrects branching and parsing when using xenium() on the 
+    # Using this version (rather than the original 'analysis_sw_version'), corrects branching and parsing when using xenium() on the
     # xeniumranger resegmented /outs/ folder path
     if specs.get(XeniumKeys.XENIUM_RANGER):
         string = specs[XeniumKeys.XENIUM_RANGER]["version"]

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -719,16 +719,15 @@ def _parse_version_of_xenium_analyzer(
     specs: dict[str, Any],
     hide_warning: bool = True,
 ) -> packaging.version.Version | None:
-    
-    #After using xeniumranger 3.0.1.1 to resegment data from xenium-1.6.0.7, a new dict is added to `specs`, named 'xenium_ranger', 
-    #which contains the key 'version' and it's value pair 'xenium-3.0.1.1' for the resegmented,
-    #which contains a new 'version' key and value is added in specs, using this version (rather than the original 'analysis_sw_version'),
-    #corrects branching and parsing when using xenium() on the xeniumranger resegmented /outs/ folder path
-    if specs.get(XeniumKeys.XENIUM_RANGER):  
-        string = specs[XeniumKeys.XENIUM_RANGER]['version']
+
+    # After using xeniumranger 3.0.1.1 to resegment data from xenium-1.6.0.7, a new dict is added to `specs`, named 'xenium_ranger',
+    # which contains the key 'version' and it's value pair 'xenium-3.0.1.1' for the resegmented,
+    # which contains a new 'version' key and value is added in specs, using this version (rather than the original 'analysis_sw_version'),
+    # corrects branching and parsing when using xenium() on the xeniumranger resegmented /outs/ folder path
+    if specs.get(XeniumKeys.XENIUM_RANGER):
+        string = specs[XeniumKeys.XENIUM_RANGER]["version"]
     else:
         string = specs[XeniumKeys.ANALYSIS_SW_VERSION]
-
 
     pattern = r"^(?:x|X)enium-(\d+\.\d+\.\d+(\.\d+-\d+)?)"
 

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -721,10 +721,10 @@ def _parse_version_of_xenium_analyzer(
 ) -> packaging.version.Version | None:
 
     # After using xeniumranger (e.g. 3.0.1.1) to resegment data from previous versions (e.g. xenium-1.6.0.7), a new dict is added to
-    # `specs`, named 'xenium_ranger', which contains the key 'version' and whose value specifies the version of xeniumrenger used to
+    # `specs`, named 'xenium_ranger', which contains the key 'version' and whose value specifies the version of xeniumranger used to
     # resegment the data (e.g. 'xenium-3.0.1.1').
-    # Using this version (rather than the original 'analysis_sw_version'), corrects branching and parsing when using xenium() on the
-    # xeniumranger resegmented /outs/ folder path
+    # When parsing the outs/ folder from the resegmented data, this version (rather than the original 'analysis_sw_version') is used
+    # whenever a code branch is dependent on the data version
     if specs.get(XeniumKeys.XENIUM_RANGER):
         string = specs[XeniumKeys.XENIUM_RANGER]["version"]
     else:


### PR DESCRIPTION
Resolves https://github.com/scverse/spatialdata-io/issues/195#issue-2459579045

- parses out xeniumranger v3.0.1.1 `version` from new spec `XENIUM_RANGER = "xenium_ranger"`, which allows the re-segmented `/outs/` data to pass through the existing `spatialdata_io.xenium()` successfully

(this is my first pull request... in any repository... please correct me if I am doing something wrong)