### PR TITLE
Update xenium.py, fix problem with hidden files in morphology_foucs direcory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,18 @@ Technologies that can be read into `SpatialData` objects using third-party libra
 This library is community maintained and is not officially endorsed by the aforementioned spatial technology companies. As such, we cannot offer any warranty of the correctness of the representation. Furthermore, we cannot ensure the correctness of the readers for every data version as the technologies evolve and update their formats. If you find a bug or notice a misrepresentation of the data please report it via our [Bug Tracking System](https://github.com/scverse/spatialdata-io/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) so that it can be addressed either by the maintainers of this library or by the community.
 
 ## Solutions to common problems
+
 ### Problem: I cannot visualize the data, everything is slow
-Solution: after parsing the data with `spatialdata-io` readers, you need to write it to Zarr and read it again. Otherwise the performance advantage given by the SpatialData Zarr format will not available. 
+
+Solution: after parsing the data with `spatialdata-io` readers, you need to write it to Zarr and read it again. Otherwise the performance advantage given by the SpatialData Zarr format will not available.
+
 ```python
 from spatialdata_io import xenium
 from spatialdata import read_zarr
 
-sdata = xenium('raw_data')
-sdata.write('data.zarr')
-sdata = read_zarr('sdata.zarr')
+sdata = xenium("raw_data")
+sdata.write("data.zarr")
+sdata = read_zarr("sdata.zarr")
 ```
 
 ## Citation

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -286,7 +286,7 @@ def xenium(
     else:
         if morphology_focus:
             morphology_focus_dir = path / XeniumKeys.MORPHOLOGY_FOCUS_DIR
-            files = {f for f in os.listdir(morphology_focus_dir) if f.endswith(".ome.tif")}
+            files = {f for f in os.listdir(morphology_focus_dir) if f.endswith(".ome.tif") and not f.startswith("._")}
             if len(files) not in [1, 4]:
                 raise ValueError(
                     "Expected 1 (no segmentation kit) or 4 (segmentation kit) files in the morphology focus directory, "


### PR DESCRIPTION
In one Xenium output directory I found these files in the `morphology_focus` directory.

I assume that one can safely ignore the hidden files starting with `._`?

```
{'morphology_focus_0000.ome.tif', '._morphology_focus_0001.ome.tif', 'morphology_focus_0003.ome.tif', 'morphology_focus_0002.ome.tif', 'morphology_focus_0001.ome.tif', '._morphology_focus_0003.ome.tif', '._morphology_focus_0002.ome.tif', '._morphology_focus_0000.ome.tif'}
```

