### PR TITLE
Rename coordinate systems in visium

### DIFF
--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -202,9 +202,9 @@ def visium(
         radius=scalefactors["spot_diameter_fullres"] / 2.0,
         index=adata.obs["spot_id"].copy(),
         transformations={
-            "global": transform_original,
-            "downscaled_hires": transform_hires,
-            "downscaled_lowres": transform_lowres,
+            dataset_id: transform_original,
+            f"{dataset_id}_downscaled_hires": transform_hires,
+            f"{dataset_id}_downscaled_lowres": transform_lowres,
         },
     )
     shapes[dataset_id] = circles
@@ -220,7 +220,7 @@ def visium(
             images[dataset_id + "_full_image"] = Image2DModel.parse(
                 full_image,
                 scale_factors=[2, 2, 2, 2],
-                transformations={"global": transform_original},
+                transformations={dataset_id: transform_original},
                 rgb=None,
                 **image_models_kwargs,
             )
@@ -231,14 +231,14 @@ def visium(
         image_hires = imread(path / VisiumKeys.IMAGE_HIRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)
         image_hires = DataArray(image_hires, dims=("c", "y", "x"))
         images[dataset_id + "_hires_image"] = Image2DModel.parse(
-            image_hires, transformations={"downscaled_hires": Identity(), "global": transform_hires.inverse()}, rgb=None
+            image_hires, transformations={f"{dataset_id}_downscaled_hires": Identity(), dataset_id: transform_hires.inverse()}, rgb=None
         )
     if (path / VisiumKeys.IMAGE_LOWRES_FILE).exists():
         image_lowres = imread(path / VisiumKeys.IMAGE_LOWRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)
         image_lowres = DataArray(image_lowres, dims=("c", "y", "x"))
         images[dataset_id + "_lowres_image"] = Image2DModel.parse(
             image_lowres,
-            transformations={"downscaled_lowres": Identity(), "global": transform_lowres.inverse()},
+            transformations={f"{dataset_id}_downscaled_lowres": Identity(), dataset_id: transform_lowres.inverse()},
             rgb=None,
         )
 

--- a/src/spatialdata_io/readers/visium.py
+++ b/src/spatialdata_io/readers/visium.py
@@ -231,7 +231,9 @@ def visium(
         image_hires = imread(path / VisiumKeys.IMAGE_HIRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)
         image_hires = DataArray(image_hires, dims=("c", "y", "x"))
         images[dataset_id + "_hires_image"] = Image2DModel.parse(
-            image_hires, transformations={f"{dataset_id}_downscaled_hires": Identity(), dataset_id: transform_hires.inverse()}, rgb=None
+            image_hires,
+            transformations={f"{dataset_id}_downscaled_hires": Identity(), dataset_id: transform_hires.inverse()},
+            rgb=None,
         )
     if (path / VisiumKeys.IMAGE_LOWRES_FILE).exists():
         image_lowres = imread(path / VisiumKeys.IMAGE_LOWRES_FILE, **imread_kwargs).squeeze().transpose(2, 0, 1)


### PR DESCRIPTION
Hi @LucaMarconato, 

here I propose to rename the coordinate systems to the dataset id as discussed [on discourse](https://discourse.scverse.org/t/dealing-with-multiple-samples/1465/9). Having unique names makes it easier when working with multiple samples. 

With this change reading in a visium sample with dataset_id `sample2` results in the following spatialdata object: 
```
SpatialData object
├── Images
│     ├── 'sample2_hires_image': DataArray[cyx] (3, 2000, 2000)
│     └── 'sample2_lowres_image': DataArray[cyx] (3, 600, 600)
├── Shapes
│     └── 'sample2': GeoDataFrame shape: (523, 2) (2D shapes)
└── Tables
      └── 'table': AnnData (523, 18085)
with coordinate systems:
    ▸ 'sample2', with elements:
        sample2_hires_image (Images), sample2_lowres_image (Images), sample2 (Shapes)
    ▸ 'sample2_downscaled_hires', with elements:
        sample2_hires_image (Images), sample2 (Shapes)
    ▸ 'sample2_downscaled_lowres', with elements:
        sample2_lowres_image (Images), sample2 (Shapes)
```

If you agree with this change, I can try to also apply it to the other readers. 

# Changelog
- changed: Visium coordinate system names use the `dataset_id` prefix (and `dataset_id` is used instead of `global`). This makes it easier to concatenate multiple samples. Tip: tou can call `sdata.rename_coordinate_systems()` if you want to restore the legacy names.