### PR TITLE
Avoid base exception type error in cosmx reader

### DIFF
--- a/src/spatialdata_io/readers/cosmx.py
+++ b/src/spatialdata_io/readers/cosmx.py
@@ -177,7 +177,7 @@ def cosmx(
     fovs_images_and_labels = set(fovs_images).intersection(set(fovs_labels))
     fovs_diff = fovs_images_and_labels.difference(set(fovs_counts))
     if len(fovs_diff):
-        raise logger.warning(
+        logger.warning(
             f"Found images and labels for {len(fovs_images)} FOVs, but only {len(fovs_counts)} FOVs in the counts file.\n"
             + f"The following FOVs are missing: {fovs_diff} \n"
             + "... will use only fovs in Table."


### PR DESCRIPTION
Changed line warning about discrepancy between fovs in labels and images from "raise logger.warning..." to just logger.warning because it causes a type error to "raise" something that doesn't inherit from the base exception class. This is the only instance of using "raise logger.warning" I was able to find in the repo, so I'm assuming this might be a typo.

See [issue 272](https://github.com/scverse/spatialdata-io/issues/272)