### PR TITLE
Include dataset id in visium HD reader

### DIFF
--- a/src/spatialdata_io/readers/visium_hd.py
+++ b/src/spatialdata_io/readers/visium_hd.py
@@ -241,9 +241,9 @@ def visium_hd(
         shapes_name = dataset_id + "_" + bin_size_str
         radius = scalefactors[VisiumHDKeys.SCALEFACTORS_SPOT_DIAMETER_FULLRES] / 2.0
         transformations = {
-            "global": transform_original,
-            "downscaled_hires": transform_hires,
-            "downscaled_lowres": transform_lowres,
+            dataset_id: transform_original,
+            f"{dataset_id}_downscaled_hires": transform_hires,
+            f"{dataset_id}_downscaled_lowres": transform_lowres,
         }
         circles = ShapesModel.parse(
             adata.obsm["spatial"],
@@ -321,7 +321,10 @@ def visium_hd(
     )
     set_transformation(
         images[dataset_id + "_hires_image"],
-        {"downscaled_hires": Identity(), "global": transform_hires.inverse()},
+        {
+            f"{dataset_id}_downscaled_hires": Identity(),
+            dataset_id: transform_hires.inverse(),
+        },
         set_all=True,
     )
 
@@ -339,7 +342,10 @@ def visium_hd(
     )
     set_transformation(
         images[dataset_id + "_lowres_image"],
-        {"downscaled_lowres": Identity(), "global": transform_lowres.inverse()},
+        {
+            f"{dataset_id}_downscaled_lowres": Identity(),
+            dataset_id: transform_lowres.inverse(),
+        },
         set_all=True,
     )
 
@@ -360,13 +366,12 @@ def visium_hd(
         transform_matrices = _get_transform_matrices(metadata, hd_layout)
         affine0 = transform_matrices["cytassist_colrow_to_spot_colrow"]
         affine1 = transform_matrices["spot_colrow_to_microscope_colrow"]
-        set_transformation(image, Sequence([affine0, affine1]), "global")
+        set_transformation(image, Sequence([affine0, affine1]), dataset_id)
 
     sdata = SpatialData(tables=tables, images=images, shapes=shapes, labels=labels)
 
     if annotate_table_by_labels:
         for bin_size_str in bin_sizes:
-
             shapes_name = dataset_id + "_" + bin_size_str
 
             # add labels layer (rasterized bins).


### PR DESCRIPTION
Follow up of #266, adapting the changes also for visium HD. 

More generally, should a `dataset_id` be included in any format read with `spatialdata-io`? It seems inconsistent to do name slots by sample in some, but not in other cases. 

# Changelog
- changed: Visium HD coordinate system names use the `dataset_id` prefix (and `dataset_id` is used instead of `global`). This makes it easier to concatenate multiple samples. Tip: tou can call `sdata.rename_coordinate_systems()` if you want to restore the legacy names.