### PR TITLE
Fix steinbock missing var column

### DIFF
--- a/src/spatialdata_io/readers/steinbock.py
+++ b/src/spatialdata_io/readers/steinbock.py
@@ -87,9 +87,11 @@ def steinbock(
     # duplicate of adata.obs['image']
     del adata.obs["Image"]
 
-    # / is an invalid character
-    adata.var["Final Concentration"] = adata.var["Final Concentration / Dilution"]
-    del adata.var["Final Concentration / Dilution"]
+    # for backwards compatibility with the demo dataset from spatialdata-io
+    if "Final Concentration / Dilution" in adata.var.columns:
+        # / is an invalid character
+        adata.var["Final Concentration"] = adata.var["Final Concentration / Dilution"]
+        del adata.var["Final Concentration / Dilution"]
 
     # replace all spaces with underscores
     adata.var.columns = adata.var.columns.str.replace(" ", "_")


### PR DESCRIPTION
Small fix in the `steinbock` reader, where a column that is not always present in the data was hardcoded. The fix maintains backward compatibility with the Steinbock dataset that we host.

Closes https://github.com/giovp/spatialdata-sandbox/issues/54