### PR TITLE
Use `global_z` in the merscope coordinates

### DIFF
--- a/src/spatialdata_io/readers/merscope.py
+++ b/src/spatialdata_io/readers/merscope.py
@@ -302,7 +302,7 @@ def _get_points(transcript_path: Path, transformations: dict[str, BaseTransforma
     transcript_df = dd.read_csv(transcript_path)
     transcripts = PointsModel.parse(
         transcript_df,
-        coordinates={"x": MerscopeKeys.GLOBAL_X, "y": MerscopeKeys.GLOBAL_Y},
+        coordinates={"x": MerscopeKeys.GLOBAL_X, "y": MerscopeKeys.GLOBAL_Y, "z": MerscopeKeys.GLOBAL_Z},
         transformations=transformations,
         feature_key=MerscopeKeys.GENE_KEY,
     )


### PR DESCRIPTION
As noticed in [this issue](https://github.com/gustaveroussy/sopa/issues/338), the MERSCOPE reader provides the `x` and `y` columns in `PointsModel.parse`, but not `z`.

The GLOBAL_Z key was already existing, but not used.
