### PR TITLE
Faster xenium polygon parsing via ragged arrays

### DIFF
--- a/src/spatialdata_io/__main__.py
+++ b/src/spatialdata_io/__main__.py
@@ -480,7 +480,6 @@ def visium_hd_wrapper(
     default=True,
     help="Whether to read cells annotations in the AnnData table. [default: True]",
 )
-@click.option("--n-jobs", type=int, default=1, help="Number of jobs. [default: 1]")
 def xenium_wrapper(
     input: str,
     output: str,
@@ -495,7 +494,6 @@ def xenium_wrapper(
     morphology_focus: bool = True,
     aligned_images: bool = True,
     cells_table: bool = True,
-    n_jobs: int = 1,
 ) -> None:
     """Xenium conversion to SpatialData."""
     sdata = xenium(  # type: ignore[name-defined] # noqa: F821
@@ -510,7 +508,6 @@ def xenium_wrapper(
         morphology_focus=morphology_focus,
         aligned_images=aligned_images,
         cells_table=cells_table,
-        n_jobs=n_jobs,
     )
     sdata.write(output)
 

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -444,9 +444,6 @@ def _get_polygons(
     index = _decode_cell_id_column(pd.Series(unique_ids))
     geo_df = GeoDataFrame({"geometry": geoms}, index=index.values)
 
-    import time
-
-    start = time.time()
     version = _parse_version_of_xenium_analyzer(specs)
     if version is not None and version < packaging.version.parse("2.0.0"):
         assert idx is not None
@@ -460,7 +457,6 @@ def _get_polygons(
                 UserWarning,
                 stacklevel=2,
             )
-    print(f"sanity check idx vs index: {time.time() - start}")
 
     scale = Scale([1.0 / specs["pixel_size"], 1.0 / specs["pixel_size"]], axes=("x", "y"))
     return ShapesModel.parse(geo_df, transformations={"global": scale})


### PR DESCRIPTION
Parsing polygons for Xenium is now ~9x faster thanks to using `from_ragged_array()` and using plain `numpy` instead of `pandas` `group_by`.