### PR TITLE
Xenium: cache zip store opening; vectorize cell id encoding

### DIFF
--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -258,7 +258,7 @@ def xenium(
             labels_name="nucleus_labels",
             labels_models_kwargs=labels_models_kwargs,
             cells_zarr=cells_zarr,
-            cell_id_str=cells_zarr_cell_id_str,
+            cell_id_str=None,
         )
     if cells_labels:
         labels["cell_labels"], cell_labels_indices_mapping = _get_labels_and_indices_mapping(

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -70,6 +70,7 @@ def xenium(
     morphology_focus: bool = True,
     aligned_images: bool = True,
     cells_table: bool = True,
+    n_jobs: int | None = None,
     gex_only: bool = True,
     imread_kwargs: Mapping[str, Any] = MappingProxyType({}),
     image_models_kwargs: Mapping[str, Any] = MappingProxyType({}),
@@ -122,6 +123,10 @@ def xenium(
         `False` and use the `xenium_aligned_image` function directly.
     cells_table
         Whether to read the cell annotations in the `AnnData` table.
+    n_jobs
+        .. deprecated::
+            ``n_jobs`` is not used anymore and will be removed in a future release. The reading time of shapes is now
+            greatly improved and does not require parallelization.
     gex_only
         Whether to load only the "Gene Expression" feature type.
     imread_kwargs
@@ -154,6 +159,13 @@ def xenium(
     ... )
     >>> sdata.write("path/to/data.zarr")
     """
+    if n_jobs is not None:
+        warnings.warn(
+            "The `n_jobs` parameter is deprecated and will be removed in a future release. "
+            "The reading time of shapes is now greatly improved and does not require parallelization.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     image_models_kwargs, labels_models_kwargs = _initialize_raster_models_kwargs(
         image_models_kwargs, labels_models_kwargs
     )

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -202,7 +202,7 @@ def xenium(
     # pre-compute cell_id strings from the zarr once, to avoid redundant conversion
     # in both _get_cells_metadata_table_from_zarr and _get_labels_and_indices_mapping.
     cells_zarr_cell_id_str: np.ndarray | None = None
-    if cells_zarr is not None:
+    if cells_zarr is not None and version is not None and version >= packaging.version.parse("1.3.0"):
         cell_id_raw = cells_zarr["cell_id"][...]
         cell_id_prefix, dataset_suffix = cell_id_raw[:, 0], cell_id_raw[:, 1]
         cells_zarr_cell_id_str = cell_id_str_from_prefix_suffix_uint32(cell_id_prefix, dataset_suffix)

--- a/tests/test_xenium.py
+++ b/tests/test_xenium.py
@@ -10,6 +10,7 @@ from spatialdata.models import TableModel, get_table_keys
 
 from spatialdata_io.__main__ import xenium_wrapper
 from spatialdata_io.readers.xenium import (
+    _cell_id_str_from_prefix_suffix_uint32_reference,
     cell_id_str_from_prefix_suffix_uint32,
     prefix_suffix_uint32_from_cell_id_str,
     xenium,
@@ -20,9 +21,22 @@ from tests._utils import skip_if_below_python_version
 def test_cell_id_str_from_prefix_suffix_uint32() -> None:
     cell_id_prefix = np.array([1, 1437536272, 1437536273], dtype=np.uint32)
     dataset_suffix = np.array([1, 1, 2])
+    expected = np.array(["aaaaaaab-1", "ffkpbaba-1", "ffkpbabb-2"])
 
-    cell_id_str = cell_id_str_from_prefix_suffix_uint32(cell_id_prefix, dataset_suffix)
-    assert np.array_equal(cell_id_str, np.array(["aaaaaaab-1", "ffkpbaba-1", "ffkpbabb-2"]))
+    result = cell_id_str_from_prefix_suffix_uint32(cell_id_prefix, dataset_suffix)
+    reference = _cell_id_str_from_prefix_suffix_uint32_reference(cell_id_prefix, dataset_suffix)
+    assert np.array_equal(result, expected)
+    assert np.array_equal(reference, expected)
+
+
+def test_cell_id_str_optimized_matches_reference() -> None:
+    rng = np.random.default_rng(42)
+    cell_id_prefix = rng.integers(0, 2**32, size=10_000, dtype=np.uint32)
+    dataset_suffix = rng.integers(0, 10, size=10_000)
+
+    result = cell_id_str_from_prefix_suffix_uint32(cell_id_prefix, dataset_suffix)
+    reference = _cell_id_str_from_prefix_suffix_uint32_reference(cell_id_prefix, dataset_suffix)
+    assert np.array_equal(result, reference)
 
 
 def test_prefix_suffix_uint32_from_cell_id_str() -> None:


### PR DESCRIPTION
After doing some profiling, I identified 2 bottlenecks:
1. the zipstore was opened multiple time and not reused.
2. the `cell_id_str_from_prefix_suffix_uint32()` had some long for loops that could be removed. 

This PR:
1. caches the opening of the cells zip store
2. vectorizes the function `cell_id_str_from_prefix_suffix_uint32()`

The second part is very interesting: Claude Opus 4.6 suggested a clever bit-shift trick which halves execution time (illustrated below, again with the help of Claude). 

Further optimization could be explored for the string concatenation, which is now driving the runtime of the function (10% of total, see flame graph), and is among the top 3 drivers of runtime.

Flame graph:
<img width="3141" height="668" alt="image" src="https://github.com/user-attachments/assets/39053716-87ae-42c3-a540-deca4f254db5" />
 
Explanation of the bit shift trick:
<img width="993" height="1353" alt="image" src="https://github.com/user-attachments/assets/40742ccd-1504-4d05-b05e-34491c6d9604" />
