### PR TITLE
Improve Xenium performance, fix multinucleate cells bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ node_modules/
 # memray report
 *.bin
 
+# speedscope report
+profile.speedscope.json
+
 # test datasets (e.g. Xenium ones)
 # symlinks
 data

--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -221,7 +221,7 @@ def xenium(
 
     if version is not None and version >= packaging.version.parse("2.0.0") and table is not None:
         assert cells_zarr is not None
-        cell_summary_table = _get_cells_metadata_table_from_zarr(cells_zarr, specs, cells_zarr_cell_id_str)
+        cell_summary_table = _get_cells_metadata_table_from_zarr(cells_zarr, cells_zarr_cell_id_str)
         try:
             _assert_arrays_equal_sampled(
                 cell_summary_table[XeniumKeys.CELL_ID].values, table.obs[XeniumKeys.CELL_ID].values
@@ -515,7 +515,7 @@ def _get_labels_and_indices_mapping(
     mask_index: int,
     labels_name: str,
     cells_zarr: zarr.Group,
-    cell_id_str: ArrayLike,
+    cell_id_str: ArrayLike | None,
     labels_models_kwargs: Mapping[str, Any] = MappingProxyType({}),
 ) -> tuple[GeoDataFrame, pd.DataFrame | None]:
     if mask_index not in [0, 1]:
@@ -572,7 +572,6 @@ def _get_labels_and_indices_mapping(
 @inject_docs(xx=XeniumKeys)
 def _get_cells_metadata_table_from_zarr(
     cells_zarr: zarr.Group,
-    specs: dict[str, Any],
     cell_id_str: ArrayLike,
 ) -> AnnData:
     """Read cells metadata from ``{xx.CELLS_ZARR}``.

--- a/tests/test_xenium.py
+++ b/tests/test_xenium.py
@@ -113,7 +113,8 @@ def test_example_data_index_integrity(dataset: str) -> None:
         assert sdata["nucleus_labels"]["scale0"]["image"].sel(y=3515.5, x=4618.5).data.compute() == 6392
         assert np.allclose(sdata['transcripts'].compute().loc[[0, 10000, 1113949]]['x'], [2.608911, 194.917831, 1227.499268])
         assert np.isclose(sdata['cell_boundaries'].loc['oipggjko-1'].geometry.centroid.x,736.4864931162789)
-        assert np.isclose(sdata['nucleus_boundaries'].loc['oipggjko-1'].geometry.centroid.x,736.4931256878282)
+        index = sdata['nucleus_boundaries']['cell_id'].index[sdata['nucleus_boundaries']['cell_id'].eq('oipggjko-1')][0]
+        assert np.isclose(sdata['nucleus_boundaries'].loc[index].geometry.centroid.x,736.4931256878282)
         assert np.array_equal(sdata['table'].X.indices[:3], [1, 3, 34])
         # fmt: on
 
@@ -138,7 +139,8 @@ def test_example_data_index_integrity(dataset: str) -> None:
         assert sdata["nucleus_labels"]["scale0"]["image"].sel(y=18.5, x=3015.5).data.compute() == 2764
         assert np.allclose(sdata['transcripts'].compute().loc[[0, 10000, 20000]]['x'], [174.258392, 12.210024, 214.759186])
         assert np.isclose(sdata['cell_boundaries'].loc['aaanbaof-1'].geometry.centroid.x, 43.96894317275074)
-        assert np.isclose(sdata['nucleus_boundaries'].loc['aaanbaof-1'].geometry.centroid.x,43.31874577809517)
+        index = sdata['nucleus_boundaries']['cell_id'].index[sdata['nucleus_boundaries']['cell_id'].eq('aaanbaof-1')][0]
+        assert np.isclose(sdata['nucleus_boundaries'].loc[index].geometry.centroid.x,43.31874577809517)
         assert np.array_equal(sdata['table'].X.indices[:3], [1, 8, 19])
         # fmt: on
 
@@ -164,7 +166,8 @@ def test_example_data_index_integrity(dataset: str) -> None:
         assert sdata["nucleus_labels"]["scale0"]["image"].sel(y=4039.5, x=93.5).data.compute() == 274
         assert np.allclose(sdata['transcripts'].compute().loc[[0, 10000, 20000]]['x'], [43.296875, 62.484375, 93.125])
         assert np.isclose(sdata['cell_boundaries'].loc['aadmbfof-1'].geometry.centroid.x, 64.54541104696033)
-        assert np.isclose(sdata['nucleus_boundaries'].loc['aadmbfof-1'].geometry.centroid.x, 65.43305896114295)
+        index = sdata['nucleus_boundaries']['cell_id'].index[sdata['nucleus_boundaries']['cell_id'].eq('aadmbfof-1')][0]
+        assert np.isclose(sdata['nucleus_boundaries'].loc[index].geometry.centroid.x, 65.43305896114295)
         assert np.array_equal(sdata['table'].X.indices[:3], [3, 49, 53])
         # fmt: on
 


### PR DESCRIPTION
The last commit message is indicative of this PR. Copy-pasting it below.

Refactor xenium polygon reader to use zarr-based indices mapping
Replace slow parquet string-based cell_id grouping with zarr polygon_sets
for both nucleus and cell boundaries. This fixes a multinucleate cell bug
where multiple nuclei sharing the same cell_id were incorrectly merged
into a single polygon, and improves performance by avoiding expensive
string operations on large parquet columns.

Key changes:
- Split _get_labels_and_indices_mapping into focused functions:
  _get_labels, _get_indices_mapping_from_zarr, _get_indices_mapping_legacy
- Nucleus boundaries now use integer label_index as GeoDataFrame index
  (with cell_id as a column), correctly handling multinucleate cells
- Cell boundaries keep string cell_id as GeoDataFrame index (legacy)
- Read only needed parquet columns for faster I/O
- Use integer label_id for fast change detection when available