### PR TITLE
Deconcatenate SpatialData to legacy AnnData objects

### DIFF
--- a/tests/test_deconcatenate.py
+++ b/tests/test_deconcatenate.py
@@ -1,16 +1,18 @@
 from anndata import AnnData
-from spatialdata_io.converters.legacy_anndata import to_legacy_anndata
 from spatialdata import SpatialData, match_sdata_to_table
 
+from spatialdata_io.converters.legacy_anndata import to_legacy_anndata
+
+
 def test_deconcatenate(
-        full_sdata: SpatialData, 
-        by: str,
-        target_coordinate_system: str,
-        sdata_table_name: str = "table",
-        region_key: str = "region",
-        join: str = "right") -> AnnData:
-    """
-    From a `SpatialData` object containing multiple regions, subset to a single region and return as an AnnData object.
+    full_sdata: SpatialData,
+    by: str,
+    target_coordinate_system: str,
+    sdata_table_name: str = "table",
+    region_key: str = "region",
+    join: str = "right",
+) -> AnnData:
+    """From a `SpatialData` object containing multiple regions, subset to a single region and return as an AnnData object.
 
     Parameters
     ----------
@@ -32,12 +34,15 @@ def test_deconcatenate(
     AnnData
         An `AnnData` object containing a subset of `full_sdata` filtered according to `region_key == by`.
     """
-
     sdata_table = full_sdata[sdata_table_name]
 
-    #maybe add "table" parameter coupled with "table_name" to follow match_sdata_to_table structure?
-    sdata_deconcat = match_sdata_to_table(full_sdata, table=sdata_table[sdata_table.obs[region_key] == by], table_name="table_name_test", how=join)
-    adata = to_legacy_anndata(sdata_deconcat, coordinate_system=target_coordinate_system, table_name="table_name_test", include_images=False)
-    #TODO: support for adding images to anndata object?
+    # maybe add "table" parameter coupled with "table_name" to follow match_sdata_to_table structure?
+    sdata_deconcat = match_sdata_to_table(
+        full_sdata, table=sdata_table[sdata_table.obs[region_key] == by], table_name="table_name_test", how=join
+    )
+    adata = to_legacy_anndata(
+        sdata_deconcat, coordinate_system=target_coordinate_system, table_name="table_name_test", include_images=False
+    )
+    # TODO: support for adding images to anndata object?
 
     return adata


### PR DESCRIPTION
Following issue #318 , I created a test `deconcatenate` function.

This function takes as input a `SpatialData` object and returns an `AnnData` object populated only with data from a specific region and transformed to a given coordinate system. Briefly, this function is a wrapper of `match_sdata_to_table()` and `to_legacy_anndata()`.

Some thoughts. Currently,

- no image is stored in the returned `AnnData` object. We can think of adding an optional parameter to load image from a given path.
- the function only returns an object at once, according to the given parameters. If one wants to save an `AnnData` object for each instance in `obs["region"]`, an external loop is needed. Maybe "deconcatenate" is a bit misleading if we keep this logic, since it's more of an extraction/subsetting.

This wrapper came handy to a case like the one I encountered in the linked issue, where I had to work with an AnnData object using the "integrated" coordinate system obtained in SpatialData following this [notebook](https://github.com/scverse/spatialdata-notebooks/blob/main/notebooks/paper_reproducibility/lundeberg.ipynb) of yours. More adaptations are required for the images, since AnnData objects don't live in a coordinate system and no actual stitched image is created at any step.

I may have messed up a bit with the test syntax you require, hope it's fine anyways.